### PR TITLE
IR-NONE Update migration strategy for incident reports from NOMIS to new IRS

### DIFF
--- a/docs/0003-migration.md
+++ b/docs/0003-migration.md
@@ -18,23 +18,24 @@ Incident reports will **not** be kept in sync and **no** data will be written ba
 There will be a one-off migration of all completed incidents from NOMIS to the new service.
 
 The proposed approach will be :-
-- Migrate all incident reporting data from NOMIS to the new service in a one of process.  These records will be role protected (mainly read-only for most users) and will be used for historical reporting and analysis. Records still process will also be read only and can only be "completed" in NOMIS.
-- In NOMIS switch off the ability to create _new_ incidents of agreed types. E.g. Self harm, Assaults and Finds. No new incidents of these types will be able to be created in NOMIS. Existing records can still be edited until "Closed"
-- Incident types can be removed on a per prison basis, for example a set of prisons can only create new incidents (of certain types) in the new service (IRS).  Other prisons can continue to use NOMIS for these types. 
-- SYSCON will need to modify the incident reporting screens in NOMIS to be "edit only" for certain incident types on a per-prison basis.
-- Existing reports in progress it will be kept in sync to the new IRS. 
-- All records originating in NOMIS will **not** be editable.
-- As old reports can be altered for many years, there will be a hard cut-off of 6-12 months on how long records can be edited in NOMIS.  After this a backend admin screen will allow these changes in DPS only.  At this point NOMIS incident screens will be removed and the NOMIS -> DPS sync will be dropped.
-- The migration process will contain all the incident data, included the question and answers used at the time and all historical changes made to that incident report.
-- The migrated data will be available for searching and viewing in the new service but will be generally read only. (except where mentioned above for special circumstances).
-- The new service will be the source of truth for all new incidents and will be the only place to create new incidents (of the types defined).
-- New incidents data will be ingested into the DPR system for reporting and down-steam applications to consume. 
-- Migrated incidents will also be ingested into the DPR system as we will want to move the need for DPR to go to NOMIS for incident data and occasionally old reports may require edits (after NOMIS screens have been removed).
-- The DPR system will also contain all the NOMIS incident reporting data and be used by the analytics platform, at a future point this data needs to be synchronised from the new service.
-- These downstream systems will need to take incident data from **two** models (both in DPR) i.e. new incidents from the new service and historical incidents from NOMIS.
-- SDT and performance hub for reporting and analysis will take their data from AP (analytics platform) but could at some future point pivot to use DPR. 
-- Over-time all other incident types will be moved to the new service and creation removed from NOMIS.
-- Once all incident types have been moved to the new service, the NOMIS incident reporting service will be decommissioned, reports turned off, screens removed, data removed from the system, code removed and tables dropped.
+* Migrate all incident reporting data from NOMIS to the new service in a one of process. These records will be role protected (mainly read-only for most users) and will be used for historical reporting and analysis. Records will be read only and can only be "edited" in NOMIS.
+* In NOMIS, switch off the ability to create new incidents of agreed types. E.g. Self harm, Assaults and Finds. No new incidents of these types will be able to be created in NOMIS. Existing records can still be edited.
+* Incident types can be removed on a per prison basis if needed (although not recommended), for example a set of prisons can only create new incidents (of certain types) in the new service (IRS). Other prisons can continue to use NOMIS for these types.
+* SYSCON will need to modify the incident reporting screens in NOMIS to be "edit only" for certain incident types on a per-prison basis. Config to drive this process from a screen will be required.
+* Existing reports created in NOMIS in progress it will be kept in sync to the new IRS.
+* All records originating in NOMIS will be viewable but not be editable in the new service.
+* New incidents data will be ingested into the DPR system for reporting and down-steam applications to consume.  It is suggested that DPR takes all data from the new IRS system which includes the old (from NOMIS) report and new reports combined into a over-aching dataset. This will allow reports ported from NOMIS to show data from both old and new data.
+* Existing NOMIS reports will need to be migrated to DPR - reports should ideally be rationalised for the new service.
+* As existing reports can be altered for many years, there will be a hard cut-off of XX months on how long records can be edited in NOMIS. After this, a backend admin screen will allow changes to NOMIS created reports to be made in the new IRS service only.
+* The migration process will contain all the incident data, included the question and answers used at the time and all historical changes made to that incident report.
+* The migrated data will be available for searching and viewing in the new service but will be generally read only. (except where mentioned above for special circumstances).
+* The new service will be the source of truth for all new incidents and will be the only place to create new incidents (of the types defined).
+* The DPR system will also contain all the NOMIS incident reporting data and be used by the analytics platform, at a future point this data needs to be synchronised from the new service.
+* These downstream systems will need to take incident data from two models (both in DPR) i.e. new incidents from the new service and historical incidents from NOMIS.
+* SDT and performance hub for reporting and analysis will take their data from AP (analytics platform) but could at some future point pivot to use DPR.
+* Over-time all other incident types will be moved to the new service and creation removed from NOMIS.
+* Once all incident types for all prisons are support in new system and reports migrated to DPR the NOMIS incident screens will be removed and the NOMIS -> DPS “trickle” will be stopped.
+* Finally, all data will be removed from NOMIS, code removed and tables dropped.
 
 Steps needed:
 **Incident reporting team.**


### PR DESCRIPTION

The changes clarify the migration process from NOMIS to the new IRS, especially focusing on how new and existing incidents will be handled. The new strategy reflects updated procedures such as disabling the creation of new incidents in NOMIS and editing existing incidents in the new service. Additionally, it outlines how incident data will be treated in downstream systems and the eventual decommission of the NOMIS incident reporting service.