### PR TITLE
IR-68: Copy OpenAPI fixes from incentives

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/OpenApiConfiguration.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
 import io.swagger.v3.oas.models.media.DateTimeSchema
 import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.media.StringSchema
@@ -38,24 +39,23 @@ class OpenApiConfiguration(
       Info().title("Incident Reporting API")
         .version(version)
         .description("API for viewing and managing incident reports")
-        .contact(Contact().name("HMPPS Digital Studio").email("feedback@digital.justice.gov.uk")),
+        .contact(Contact().name("HMPPS Digital Studio").email("feedback@digital.justice.gov.uk"))
+        .license(License().name("MIT")),
     )
     .components(
-      Components().addSecuritySchemes(
-        "bearer-jwt",
-        SecurityScheme()
-          .type(SecurityScheme.Type.HTTP)
-          .scheme("bearer")
-          .bearerFormat("JWT")
-          .`in`(SecurityScheme.In.HEADER)
-          .name("Authorization"),
-      )
+      Components()
+        .addSecuritySchemes(
+          "bearer-jwt",
+          SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT"),
+        )
         .addSecuritySchemes(
           "hmpps-auth",
           SecurityScheme()
-            .flows(getFlows())
             .type(SecurityScheme.Type.OAUTH2)
-            .openIdConnectUrl("$oauthUrl/.well-known/openid-configuration"),
+            .flows(getFlows()),
         ),
     )
     .addSecurityItem(SecurityRequirement().addList("bearer-jwt", listOf("read", "write")))


### PR DESCRIPTION
`securitySchemes` in OpenAPI output had a few issues…
1) `in` and `name` only apply to “apiKey” type (not the “http” that we use)
2) `openIdConnectUrl` only applies to “openIdConnect” type (not the “oauth2” that we use)
See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.1.md#fixed-fields-23

[Copied from incentives-api](https://github.com/ministryofjustice/hmpps-incentives-api/pull/549/commits/9f943c4cadbb81a3d176c67a6157d511bfd555b1)