### PR TITLE
Removed unnecessary `Serializable` marker interface from JPA entities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/CorrectionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/CorrectionRequest.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.CorrectionReason
-import java.io.Serializable
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.CorrectionRequest as CorrectionRequestDto
 
@@ -26,7 +25,7 @@ class CorrectionRequest(
 
   val correctionRequestedBy: String,
   val correctionRequestedAt: LocalDateTime,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import org.hibernate.Hibernate
-import java.io.Serializable
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Event as EventDto
 
@@ -39,7 +38,7 @@ class Event(
   val createdDate: LocalDateTime,
   var lastModifiedDate: LocalDateTime,
   var lastModifiedBy: String,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Evidence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Evidence.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import org.hibernate.Hibernate
-import java.io.Serializable
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Evidence as EvidenceDto
 
 @Entity
@@ -22,7 +21,7 @@ class Evidence(
   // TODO: should `type` be an enum?
   val type: String,
   val description: String,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderColumn
 import org.hibernate.Hibernate
-import java.io.Serializable
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.HistoricalQuestion as HistoricalQuestionDto
 
@@ -30,7 +29,7 @@ class HistoricalQuestion(
   @OneToMany(mappedBy = "historicalQuestion", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @OrderColumn(name = "sequence")
   private val responses: MutableList<HistoricalResponse> = mutableListOf(),
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import org.hibernate.Hibernate
-import java.io.Serializable
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.HistoricalResponse as HistoricalResponseDto
 
@@ -27,7 +26,7 @@ class HistoricalResponse(
 
   val recordedBy: String,
   val recordedOn: LocalDateTime,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/History.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/History.kt
@@ -12,7 +12,6 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
-import java.io.Serializable
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.History as HistoryDto
 
@@ -33,7 +32,7 @@ class History(
 
   @OneToMany(mappedBy = "history", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
   val questions: MutableList<HistoricalQuestion> = mutableListOf(),
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Location.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import org.hibernate.Hibernate
-import java.io.Serializable
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Location as LocationDto
 
 @Entity
@@ -24,7 +23,7 @@ class Location(
   // TODO: should `type` be an enum?
   val type: String,
   val description: String,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/PrisonerInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/PrisonerInvolvement.kt
@@ -11,7 +11,6 @@ import jakarta.persistence.ManyToOne
 import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerOutcome
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerRole
-import java.io.Serializable
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.PrisonerInvolvement as PrisonerInvolvementDto
 
 @Entity
@@ -32,7 +31,7 @@ class PrisonerInvolvement(
   val outcome: PrisonerOutcome? = null,
 
   val comment: String? = null,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderColumn
 import org.hibernate.Hibernate
-import java.io.Serializable
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Question as QuestionDto
 
@@ -30,7 +29,7 @@ class Question(
   @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @OrderColumn(name = "sequence")
   private val responses: MutableList<Response> = mutableListOf(),
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -22,7 +22,6 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
-import java.io.Serializable
 import java.time.Clock
 import java.time.LocalDateTime
 import java.util.UUID
@@ -99,7 +98,7 @@ class Report(
   val createdDate: LocalDateTime,
   var lastModifiedDate: LocalDateTime,
   var lastModifiedBy: String,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import org.hibernate.Hibernate
-import java.io.Serializable
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Response as ResponseDto
 
@@ -27,7 +26,7 @@ class Response(
 
   val recordedBy: String,
   val recordedOn: LocalDateTime,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/StaffInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/StaffInvolvement.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
-import java.io.Serializable
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.StaffInvolvement as StaffInvolvementDto
 
 @Entity
@@ -28,7 +27,7 @@ class StaffInvolvement(
   val staffRole: StaffRole,
 
   val comment: String? = null,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/StatusHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/StatusHistory.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
-import java.io.Serializable
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.StatusHistory as StatusHistoryDto
 
@@ -28,7 +27,7 @@ class StatusHistory(
 
   val setOn: LocalDateTime,
   val setBy: String,
-) : Serializable {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false


### PR DESCRIPTION
We don't manually serialize JPA entities to files or over-the-wire and tests pass so these seems to be unnecessary.

(if in the future we find that these are required we can easily readd)