### PR TITLE
IR-68: Fix initial database setup

### DIFF
--- a/src/main/resources/db/migration/V1_1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1_1__initial_schema.sql
@@ -117,7 +117,7 @@ create table question
     report_id              uuid              not null
         constraint question_report_fk references report (id) on delete cascade,
     sequence               integer default 0 not null,
-    code                   varchar(60),
+    code                   varchar(60)       not null,
     question               text              not null,
     additional_information text
 );


### PR DESCRIPTION
The question `code` field was already expected to be non-null throughout the application.

NB: will require database resets when merging