### PR TITLE
IR-224: NOMIS sync endpoint updates report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
@@ -56,7 +56,7 @@ fun NomisReport.toNewEntity(clock: Clock): Report {
 
 fun Report.addNomisStaffInvolvements(staffParties: Collection<NomisStaffParty>) {
   staffParties.forEach {
-    addStaffInvolved(
+    this.addStaffInvolved(
       staffRole = StaffRole.fromNomisCode(it.role.code),
       username = it.staff.username,
       comment = it.comment,
@@ -66,7 +66,7 @@ fun Report.addNomisStaffInvolvements(staffParties: Collection<NomisStaffParty>) 
 
 fun Report.addNomisPrisonerInvolvements(offenderParties: Collection<NomisOffenderParty>) {
   offenderParties.forEach {
-    addPrisonerInvolved(
+    this.addPrisonerInvolved(
       prisonerNumber = it.offender.offenderNo,
       prisonerRole = PrisonerRole.fromNomisCode(it.role.code),
       prisonerOutcome = it.outcome?.let { prisonerOutcome -> PrisonerOutcome.fromNomisCode(prisonerOutcome.code) },
@@ -77,7 +77,7 @@ fun Report.addNomisPrisonerInvolvements(offenderParties: Collection<NomisOffende
 
 fun Report.addNomisCorrectionRequests(correctionRequests: Collection<NomisRequirement>) {
   correctionRequests.forEach {
-    addCorrectionRequest(
+    this.addCorrectionRequest(
       correctionRequestedBy = it.staff.username,
       correctionRequestedAt = it.date.atStartOfDay(),
       descriptionOfChange = it.comment ?: "NO DETAILS GIVEN",
@@ -88,7 +88,7 @@ fun Report.addNomisCorrectionRequests(correctionRequests: Collection<NomisRequir
 
 fun Report.addNomisQuestions(questions: Collection<NomisQuestion>) {
   questions.sortedBy { it.sequence }.forEach { question ->
-    val dataItem = addQuestion(
+    val dataItem = this.addQuestion(
       code = "QID-%012d".format(question.questionId),
       question = question.question,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
@@ -45,34 +45,50 @@ fun NomisReport.toNewEntity(clock: Clock): Report {
   )
   report.addStatusHistory(status, reportedDateTime, reportingStaff.username)
 
+  report.addNomisStaffInvolvements(staffParties)
+  report.addNomisPrisonerInvolvements(offenderParties)
+  report.addNomisCorrectionRequests(requirements)
+  report.addNomisQuestions(questions)
+  report.addNomisHistory(history)
+
+  return report
+}
+
+fun Report.addNomisStaffInvolvements(staffParties: Collection<NomisStaffParty>) {
   staffParties.forEach {
-    report.addStaffInvolved(
+    addStaffInvolved(
       staffRole = StaffRole.fromNomisCode(it.role.code),
       username = it.staff.username,
       comment = it.comment,
     )
   }
+}
 
+fun Report.addNomisPrisonerInvolvements(offenderParties: Collection<NomisOffenderParty>) {
   offenderParties.forEach {
-    report.addPrisonerInvolved(
+    addPrisonerInvolved(
       prisonerNumber = it.offender.offenderNo,
       prisonerRole = PrisonerRole.fromNomisCode(it.role.code),
       prisonerOutcome = it.outcome?.let { prisonerOutcome -> PrisonerOutcome.fromNomisCode(prisonerOutcome.code) },
       comment = it.comment,
     )
   }
+}
 
-  requirements.forEach {
-    report.addCorrectionRequest(
+fun Report.addNomisCorrectionRequests(correctionRequests: Collection<NomisRequirement>) {
+  correctionRequests.forEach {
+    addCorrectionRequest(
       correctionRequestedBy = it.staff.username,
       correctionRequestedAt = it.date.atStartOfDay(),
       descriptionOfChange = it.comment ?: "NO DETAILS GIVEN",
       reason = CorrectionReason.NOT_SPECIFIED,
     )
   }
+}
 
+fun Report.addNomisQuestions(questions: Collection<NomisQuestion>) {
   questions.sortedBy { it.sequence }.forEach { question ->
-    val dataItem = report.addQuestion(
+    val dataItem = addQuestion(
       code = "QID-%012d".format(question.questionId),
       question = question.question,
     )
@@ -84,13 +100,15 @@ fun NomisReport.toNewEntity(clock: Clock): Report {
           response = answer.answer!!,
           additionalInformation = answer.comment,
           recordedBy = answer.recordingStaff.username,
-          recordedOn = report.reportedDate,
+          recordedOn = this.reportedDate,
         )
       }
   }
+}
 
+fun Report.addNomisHistory(history: Collection<NomisHistory>) {
   history.forEach { history ->
-    val historyRecord = report.addHistory(
+    val historyRecord = this.addHistory(
       type = Type.fromNomisCode(history.type),
       incidentChangeDate = history.incidentChangeDate.atStartOfDay(),
       staffChanged = history.incidentChangeStaff.username,
@@ -109,11 +127,9 @@ fun NomisReport.toNewEntity(clock: Clock): Report {
             response = answer.answer!!,
             additionalInformation = answer.comment,
             recordedBy = answer.recordingStaff.username,
-            recordedOn = report.reportedDate,
+            recordedOn = this.reportedDate,
           )
         }
     }
   }
-
-  return report
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/CorrectionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/CorrectionRequest.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.CorrectionReason
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.CorrectionRequest as CorrectionRequestDto
@@ -26,19 +25,6 @@ class CorrectionRequest(
   val correctionRequestedBy: String,
   val correctionRequestedAt: LocalDateTime,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as CorrectionRequest
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "CorrectionRequest(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
-import org.hibernate.Hibernate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Event as EventDto
 
@@ -39,19 +38,6 @@ class Event(
   var lastModifiedDate: LocalDateTime,
   var lastModifiedBy: String,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as Event
-
-    return eventId == other.eventId
-  }
-
-  override fun hashCode(): Int {
-    return eventId.hashCode()
-  }
-
   override fun toString(): String {
     return "Event(eventId=$eventId)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
@@ -25,8 +25,8 @@ class Event(
   @Column(nullable = false, unique = true, length = 25)
   val eventId: String,
 
-  val eventDateAndTime: LocalDateTime,
-  val prisonId: String,
+  var eventDateAndTime: LocalDateTime,
+  var prisonId: String,
 
   var title: String,
   var description: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Evidence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Evidence.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Evidence as EvidenceDto
 
 @Entity
@@ -22,19 +21,6 @@ class Evidence(
   val type: String,
   val description: String,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as Evidence
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "Evidence(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
@@ -9,7 +9,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderColumn
-import org.hibernate.Hibernate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.HistoricalQuestion as HistoricalQuestionDto
 
@@ -31,19 +30,6 @@ class HistoricalQuestion(
   @OrderColumn(name = "sequence")
   private val responses: MutableList<HistoricalResponse> = mutableListOf(),
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as HistoricalQuestion
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "HistoricalQuestion(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import org.hibernate.Hibernate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.HistoricalResponse as HistoricalResponseDto
 
@@ -27,19 +26,6 @@ class HistoricalResponse(
   val recordedBy: String,
   val recordedOn: LocalDateTime,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as HistoricalResponse
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "HistoricalResponse(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/History.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/History.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
-import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.History as HistoryDto
@@ -33,19 +32,6 @@ class History(
   @OneToMany(mappedBy = "history", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
   val questions: MutableList<HistoricalQuestion> = mutableListOf(),
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as History
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "History(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Location.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Location as LocationDto
 
 @Entity
@@ -24,19 +23,6 @@ class Location(
   val type: String,
   val description: String,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as Location
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "Location(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/PrisonerInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/PrisonerInvolvement.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerOutcome
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerRole
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.PrisonerInvolvement as PrisonerInvolvementDto
@@ -32,19 +31,6 @@ class PrisonerInvolvement(
 
   val comment: String? = null,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as PrisonerInvolvement
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "PrisonerInvolvement(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
@@ -9,7 +9,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderColumn
-import org.hibernate.Hibernate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Question as QuestionDto
 
@@ -31,19 +30,6 @@ class Question(
   @OrderColumn(name = "sequence")
   private val responses: MutableList<Response> = mutableListOf(),
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as Question
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "Question(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisCorrectionRequests
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisPrisonerInvolvements
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisStaffInvolvements
 import java.time.Clock
@@ -265,6 +266,9 @@ class Report(
 
     prisonersInvolved.clear()
     addNomisPrisonerInvolvements(upsert.offenderParties)
+
+    correctionRequests.clear()
+    addNomisCorrectionRequests(upsert.requirements)
 
     // TODO: need to compare and update other fields and related entities
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -258,6 +258,15 @@ class Report(
     // TODO: Also update history from syncRequest (`history` field)
     // history include history of type changes, questions, etc...
 
+    staffInvolved.clear()
+    upsert.staffParties.forEach {
+      addStaffInvolved(
+        staffRole = StaffRole.fromNomisCode(it.role.code),
+        username = it.staff.username,
+        comment = it.comment,
+      )
+    }
+
     // TODO: need to compare and update other fields and related entities
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisCorrectionRequests
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisPrisonerInvolvements
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisQuestions
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisStaffInvolvements
 import java.time.Clock
 import java.time.LocalDateTime
@@ -269,6 +270,9 @@ class Report(
 
     correctionRequests.clear()
     addNomisCorrectionRequests(upsert.requirements)
+
+    questions.clear()
+    addNomisQuestions(upsert.questions)
 
     // TODO: need to compare and update other fields and related entities
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -12,7 +12,6 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderBy
 import jakarta.persistence.OrderColumn
-import org.hibernate.Hibernate
 import org.hibernate.annotations.GenericGenerator
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.CorrectionReason
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
@@ -104,19 +103,6 @@ class Report(
   var lastModifiedDate: LocalDateTime,
   var lastModifiedBy: String,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as Report
-
-    return incidentNumber == other.incidentNumber
-  }
-
-  override fun hashCode(): Int {
-    return incidentNumber.hashCode()
-  }
-
   override fun toString(): String {
     return "Report(incidentNumber=$incidentNumber)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisCorrectionRequests
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisHistory
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisPrisonerInvolvements
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisQuestions
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisStaffInvolvements
@@ -274,7 +275,8 @@ class Report(
     questions.clear()
     addNomisQuestions(upsert.questions)
 
-    // TODO: need to compare and update other fields and related entities
+    history.clear()
+    addNomisHistory(upsert.history)
   }
 
   fun toDto() = ReportDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -253,6 +253,11 @@ class Report(
       addStatusHistory(newStatus, now, updatedBy)
     }
 
+    type = Type.fromNomisCode(upsert.type)
+
+    // TODO: Also update history from syncRequest (`history` field)
+    // history include history of type changes, questions, etc...
+
     // TODO: need to compare and update other fields and related entities
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -234,6 +234,11 @@ class Report(
 
     type = Type.fromNomisCode(upsert.type)
 
+    // NOTE: Currently we update the event information as well on update.
+    //       For some of these fields makes more sense because that's explicitly
+    //       the intent (e.g. `incidentDateTime`, `prisonId`, etc... are also in the event)
+    //       For Event's title/description may make less sense but we're keeping this in
+    //       as well for now.
     incidentDateAndTime = upsert.incidentDateTime
     event.eventDateAndTime = incidentDateAndTime
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -267,6 +267,16 @@ class Report(
       )
     }
 
+    prisonersInvolved.clear()
+    upsert.offenderParties.forEach {
+      addPrisonerInvolved(
+        prisonerNumber = it.offender.offenderNo,
+        prisonerRole = PrisonerRole.fromNomisCode(it.role.code),
+        prisonerOutcome = it.outcome?.let { prisonerOutcome -> PrisonerOutcome.fromNomisCode(prisonerOutcome.code) },
+        comment = it.comment,
+      )
+    }
+
     // TODO: need to compare and update other fields and related entities
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -22,6 +22,8 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisPrisonerInvolvements
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisStaffInvolvements
 import java.time.Clock
 import java.time.LocalDateTime
 import java.util.UUID
@@ -259,23 +261,10 @@ class Report(
     // history include history of type changes, questions, etc...
 
     staffInvolved.clear()
-    upsert.staffParties.forEach {
-      addStaffInvolved(
-        staffRole = StaffRole.fromNomisCode(it.role.code),
-        username = it.staff.username,
-        comment = it.comment,
-      )
-    }
+    addNomisStaffInvolvements(upsert.staffParties)
 
     prisonersInvolved.clear()
-    upsert.offenderParties.forEach {
-      addPrisonerInvolved(
-        prisonerNumber = it.offender.offenderNo,
-        prisonerRole = PrisonerRole.fromNomisCode(it.role.code),
-        prisonerOutcome = it.outcome?.let { prisonerOutcome -> PrisonerOutcome.fromNomisCode(prisonerOutcome.code) },
-        comment = it.comment,
-      )
-    }
+    addNomisPrisonerInvolvements(upsert.offenderParties)
 
     // TODO: need to compare and update other fields and related entities
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -260,9 +260,6 @@ class Report(
 
     type = Type.fromNomisCode(upsert.type)
 
-    // TODO: Also update history from syncRequest (`history` field)
-    // history include history of type changes, questions, etc...
-
     staffInvolved.clear()
     addNomisStaffInvolvements(upsert.staffParties)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import org.hibernate.Hibernate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Response as ResponseDto
 
@@ -27,19 +26,6 @@ class Response(
   val recordedBy: String,
   val recordedOn: LocalDateTime,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as Response
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "Response(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/StaffInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/StaffInvolvement.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.StaffInvolvement as StaffInvolvementDto
 
@@ -28,19 +27,6 @@ class StaffInvolvement(
 
   val comment: String? = null,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as StaffInvolvement
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "StaffInvolvement(id=$id)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/StatusHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/StatusHistory.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.StatusHistory as StatusHistoryDto
@@ -28,19 +27,6 @@ class StatusHistory(
   val setOn: LocalDateTime,
   val setBy: String,
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-
-    other as StatusHistory
-
-    return id == other.id
-  }
-
-  override fun hashCode(): Int {
-    return id?.hashCode() ?: 0
-  }
-
   override fun toString(): String {
     return "StatusHistory(id=$id)"
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
@@ -133,7 +133,6 @@ class NomisDtoToJpaMappingEdgeCaseTest {
       assertThat(existingReportEntity.lastModifiedBy).isEqualTo("user1")
 
       val eventEntity = existingReportEntity.event
-      // TODO: changes not copied to event, should they be? probably not (then keep assertions but drop comment)
       assertThat(eventEntity.title).isEqualTo("TITLE")
       assertThat(eventEntity.description).isEqualTo("DESCRIPTION")
       assertThat(eventEntity.createdDate).isEqualTo(yesterday)
@@ -155,7 +154,6 @@ class NomisDtoToJpaMappingEdgeCaseTest {
       assertThat(existingReportEntity.description).isEqualTo("DESCRIPTION")
 
       val eventEntity = existingReportEntity.event
-      // TODO: changes not copied to event, should they be? probably not (then keep assertions but drop comment)
       assertThat(eventEntity.title).isEqualTo("NO DETAILS GIVEN")
       assertThat(eventEntity.description).isEqualTo("DESCRIPTION")
     }
@@ -174,7 +172,6 @@ class NomisDtoToJpaMappingEdgeCaseTest {
       assertThat(existingReportEntity.description).isEqualTo("NO DETAILS GIVEN")
 
       val eventEntity = existingReportEntity.event
-      // TODO: changes not copied to event, should they be? probably not (then keep assertions but drop comment)
       assertThat(eventEntity.title).isEqualTo("TITLE")
       assertThat(eventEntity.description).isEqualTo("NO DETAILS GIVEN")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
@@ -134,11 +134,11 @@ class NomisDtoToJpaMappingEdgeCaseTest {
 
       val eventEntity = existingReportEntity.event
       // TODO: changes not copied to event, should they be? probably not (then keep assertions but drop comment)
-      assertThat(eventEntity.title).isEqualTo("An event occurred")
-      assertThat(eventEntity.description).isEqualTo("Details of the event")
+      assertThat(eventEntity.title).isEqualTo("TITLE")
+      assertThat(eventEntity.description).isEqualTo("DESCRIPTION")
       assertThat(eventEntity.createdDate).isEqualTo(yesterday)
-      assertThat(eventEntity.lastModifiedDate).isEqualTo(yesterday)
-      assertThat(eventEntity.lastModifiedBy).isEqualTo("old-user")
+      assertThat(eventEntity.lastModifiedDate).isEqualTo(now)
+      assertThat(eventEntity.lastModifiedBy).isEqualTo("user1")
     }
 
     @Test
@@ -156,8 +156,8 @@ class NomisDtoToJpaMappingEdgeCaseTest {
 
       val eventEntity = existingReportEntity.event
       // TODO: changes not copied to event, should they be? probably not (then keep assertions but drop comment)
-      assertThat(eventEntity.title).isEqualTo("An event occurred")
-      assertThat(eventEntity.description).isEqualTo("Details of the event")
+      assertThat(eventEntity.title).isEqualTo("NO DETAILS GIVEN")
+      assertThat(eventEntity.description).isEqualTo("DESCRIPTION")
     }
 
     @Test
@@ -175,8 +175,8 @@ class NomisDtoToJpaMappingEdgeCaseTest {
 
       val eventEntity = existingReportEntity.event
       // TODO: changes not copied to event, should they be? probably not (then keep assertions but drop comment)
-      assertThat(eventEntity.title).isEqualTo("An event occurred")
-      assertThat(eventEntity.description).isEqualTo("Details of the event")
+      assertThat(eventEntity.title).isEqualTo("TITLE")
+      assertThat(eventEntity.description).isEqualTo("NO DETAILS GIVEN")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -813,6 +813,62 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 ),
               ),
             ),
+            history = listOf(
+              NomisHistory(
+                1,
+                "DAMAGE",
+                "Damage",
+                incidentChangeDate = LocalDate.now(clock),
+                incidentChangeStaff = reportingStaff,
+                questions = listOf(
+                  NomisHistoryQuestion(
+                    1,
+                    1,
+                    "Old question 1",
+                    listOf(
+                      NomisHistoryResponse(1, 1, "Old answer 1", "comment 1", reportingStaff),
+                      NomisHistoryResponse(2, 2, "Old answer 2", "comment 2", reportingStaff),
+                    ),
+                  ),
+                  NomisHistoryQuestion(
+                    2,
+                    2,
+                    "Old question 2",
+                    listOf(
+                      NomisHistoryResponse(4, 1, "Old answer 1", "comment 1", reportingStaff),
+                      NomisHistoryResponse(5, 2, "Old answer 2", "comment 2", reportingStaff),
+                    ),
+                  ),
+                ),
+              ),
+              NomisHistory(
+                2,
+                "BOMB",
+                "Bomb",
+                incidentChangeDate = LocalDate.now(clock).minusDays(2),
+                incidentChangeStaff = reportingStaff,
+                questions = listOf(
+                  NomisHistoryQuestion(
+                    11,
+                    1,
+                    "Old old question 1",
+                    listOf(
+                      NomisHistoryResponse(12, 1, "Old old answer 1", "comment 1", reportingStaff),
+                      NomisHistoryResponse(22, 2, "Old old answer 2", "comment 2", reportingStaff),
+                    ),
+                  ),
+                  NomisHistoryQuestion(
+                    22,
+                    2,
+                    "Old old question 2",
+                    listOf(
+                      NomisHistoryResponse(44, 1, "Old old answer 1", "comment 1", reportingStaff),
+                      NomisHistoryResponse(55, 2, "Old old answer 2", "comment 2", reportingStaff),
+                    ),
+                  ),
+                ),
+              ),
+            ),
           ),
         )
         webTestClient.post().uri("/sync/upsert")
@@ -915,12 +971,6 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                           "recordedBy": "user2",
                           "recordedOn": "2023-12-05T12:34:56",
                           "additionalInformation": "comment 2"
-                        },
-                        {
-                          "response": "Old answer 3",
-                          "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
-                          "additionalInformation": "comment 3"
                         }
                       ],
                       "additionalInformation": null
@@ -940,37 +990,51 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                           "recordedBy": "user2",
                           "recordedOn": "2023-12-05T12:34:56",
                           "additionalInformation": "comment 2"
-                        },
-                        {
-                          "response": "Old answer 3",
-                          "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
-                          "additionalInformation": "comment 3"
                         }
                       ],
                       "additionalInformation": null
-                    },
+                    }
+                  ]
+                },
+                {
+                  "type": "BOMB_THREAT",
+                  "changeDate": "2023-12-03T00:00:00",
+                  "changeStaffUsername": "user2",
+                  "questions": [
                     {
-                      "code": "QID-000000000003",
-                      "question": "Old question 3",
+                      "code": "QID-000000000011",
+                      "question": "Old old question 1",
                       "responses": [
                         {
-                          "response": "Old answer 1",
+                          "response": "Old old answer 1",
                           "recordedBy": "user2",
                           "recordedOn": "2023-12-05T12:34:56",
                           "additionalInformation": "comment 1"
                         },
                         {
-                          "response": "Old answer 2",
+                          "response": "Old old answer 2",
                           "recordedBy": "user2",
                           "recordedOn": "2023-12-05T12:34:56",
                           "additionalInformation": "comment 2"
-                        },
+                        }
+                      ],
+                      "additionalInformation": null
+                    },
+                    {
+                      "code": "QID-000000000022",
+                      "question": "Old old question 2",
+                      "responses": [
                         {
-                          "response": "Old answer 3",
+                          "response": "Old old answer 1",
                           "recordedBy": "user2",
                           "recordedOn": "2023-12-05T12:34:56",
-                          "additionalInformation": "comment 3"
+                          "additionalInformation": "comment 1"
+                        },
+                        {
+                          "response": "Old old answer 2",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 2"
                         }
                       ],
                       "additionalInformation": null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -761,7 +761,31 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               NomisStaffParty(reportingStaff, NomisCode("PAS", "Present at scene"), "REPORTER"),
               NomisStaffParty(
                 NomisStaff("JAMESQ", 2, "James", "Quids"),
-                NomisCode("PAS", "Present at scene"), "James was also present actually"),
+                NomisCode("PAS", "Present at scene"),
+                "James was also present actually",
+              ),
+            ),
+            offenderParties = listOf(
+              NomisOffenderParty(
+                offender = NomisOffender(
+                  offenderNo = "B2222BB",
+                  firstName = "John",
+                  lastName = "Also-Smith",
+                ),
+                role = NomisCode("HOST", "Hostage"),
+                outcome = NomisCode("TRN", "Transfer"),
+                comment = "Prisoner was transferred after incident",
+              ),
+              NomisOffenderParty(
+                offender = NomisOffender(
+                  offenderNo = "A1234AA",
+                  firstName = "Trevor",
+                  lastName = "Smith",
+                ),
+                role = NomisCode("PERP", "Perpetrator"),
+                outcome = NomisCode("ILOC", "ILOC"),
+                comment = "Trevor took another prisoner hostage",
+              ),
             ),
           ),
         )
@@ -979,10 +1003,16 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               ],
               "prisonersInvolved": [
                 {
+                  "prisonerNumber": "B2222BB",
+                  "prisonerRole": "HOSTAGE",
+                  "outcome": "TRANSFER",
+                  "comment": "Prisoner was transferred after incident"
+                },
+                {
                   "prisonerNumber": "A1234AA",
                   "prisonerRole": "PERPETRATOR",
-                  "outcome": "ACCT",
-                  "comment": "Comment"
+                  "outcome": "LOCAL_INVESTIGATION",
+                  "comment": "Trevor took another prisoner hostage"
                 }
               ],
               "locations": [],

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -787,6 +787,10 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 comment = "Trevor took another prisoner hostage",
               ),
             ),
+            requirements = listOf(
+              NomisRequirement("Also the description", LocalDate.now(clock), reportingStaff, "MDI"),
+              NomisRequirement("Could you update the title please", LocalDate.now(clock).minusWeeks(1), reportingStaff, "MDI"),
+            ),
           ),
         )
         webTestClient.post().uri("/sync/upsert")
@@ -1020,9 +1024,15 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               "correctionRequests": [
                 {
                   "reason": "NOT_SPECIFIED",
-                  "descriptionOfChange": "Change 1",
+                  "descriptionOfChange": "Also the description",
                   "correctionRequestedBy": "user2",
                   "correctionRequestedAt": "2023-12-05T00:00:00"
+                },
+                {
+                  "reason": "NOT_SPECIFIED",
+                  "descriptionOfChange": "Could you update the title please",
+                  "correctionRequestedBy": "user2",
+                  "correctionRequestedAt": "2023-11-28T00:00:00"
                 }
               ],
               "reportedBy": "USER1",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -863,7 +863,90 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                   "additionalInformation": null
                 }
               ],
-              "history": [],
+              "history": [
+                {
+                  "type": "DAMAGE",
+                  "changeDate": "2023-12-05T00:00:00",
+                  "changeStaffUsername": "user2",
+                  "questions": [
+                    {
+                      "code": "QID-000000000001",
+                      "question": "Old question 1",
+                      "responses": [
+                        {
+                          "response": "Old answer 1",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 1"
+                        },
+                        {
+                          "response": "Old answer 2",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 2"
+                        },
+                        {
+                          "response": "Old answer 3",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 3"
+                        }
+                      ],
+                      "additionalInformation": null
+                    },
+                    {
+                      "code": "QID-000000000002",
+                      "question": "Old question 2",
+                      "responses": [
+                        {
+                          "response": "Old answer 1",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 1"
+                        },
+                        {
+                          "response": "Old answer 2",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 2"
+                        },
+                        {
+                          "response": "Old answer 3",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 3"
+                        }
+                      ],
+                      "additionalInformation": null
+                    },
+                    {
+                      "code": "QID-000000000003",
+                      "question": "Old question 3",
+                      "responses": [
+                        {
+                          "response": "Old answer 1",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 1"
+                        },
+                        {
+                          "response": "Old answer 2",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 2"
+                        },
+                        {
+                          "response": "Old answer 3",
+                          "recordedBy": "user2",
+                          "recordedOn": "2023-12-05T12:34:56",
+                          "additionalInformation": "comment 3"
+                        }
+                      ],
+                      "additionalInformation": null
+                    }
+                  ]
+                }
+              ],
               "historyOfStatuses": [
                 {
                   "status": "DRAFT",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -800,7 +800,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                   "setBy": "user2"
                 }
               ],
-              "staffInvolved": [],
+              "staffInvolved": [
+                {
+                  "staffUsername": "user2",
+                  "staffRole": "PRESENT_AT_SCENE",
+                  "comment": "REPORTER"
+                }
+              ],
               "prisonersInvolved": [],
               "locations": [],
               "evidence": [],

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -786,7 +786,83 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "lastModifiedDate": "2023-12-05T12:34:56",
                 "lastModifiedBy": "USER1"
               },
-              "questions": [],
+              "questions": [
+                {
+                  "code": "QID-000000000004",
+                  "question": "Question 1",
+                  "responses": [
+                    {
+                      "response": "Answer 1",
+                      "recordedBy": "user2",
+                      "recordedOn": "2023-12-05T12:34:56",
+                      "additionalInformation": "comment 1"
+                    },
+                    {
+                      "response": "Answer 2",
+                      "recordedBy": "user2",
+                      "recordedOn": "2023-12-05T12:34:56",
+                      "additionalInformation": "comment 2"
+                    },
+                    {
+                      "response": "Answer 3",
+                      "recordedBy": "user2",
+                      "recordedOn": "2023-12-05T12:34:56",
+                      "additionalInformation": "comment 3"
+                    }
+                  ],
+                  "additionalInformation": null
+                },
+                {
+                  "code": "QID-000000000005",
+                  "question": "Question 2",
+                  "responses": [
+                    {
+                      "response": "Answer 1",
+                      "recordedBy": "user2",
+                      "recordedOn": "2023-12-05T12:34:56",
+                      "additionalInformation": "comment 1"
+                    },
+                    {
+                      "response": "Answer 2",
+                      "recordedBy": "user2",
+                      "recordedOn": "2023-12-05T12:34:56",
+                      "additionalInformation": "comment 2"
+                    },
+                    {
+                      "response": "Answer 3",
+                      "recordedBy": "user2",
+                      "recordedOn": "2023-12-05T12:34:56",
+                      "additionalInformation": "comment 3"
+                    }
+                  ],
+                  "additionalInformation": null
+                },
+                {
+                  "code": "QID-000000000006",
+                  "question": "Question 3",
+                  "responses": [
+                    {
+                      "response": "Answer 1",
+                      "recordedBy": "user2",
+                      "recordedOn": "2023-12-05T12:34:56",
+                      "additionalInformation": "comment 1"
+                    },
+                    {
+                      "response": "Answer 2",
+                      "recordedBy": "user2",
+                      "recordedOn": "2023-12-05T12:34:56",
+                      "additionalInformation": "comment 2"
+                    },
+                    {
+                      "response": "Answer 3",
+                      "recordedBy": "user2",
+                      "recordedOn": "2023-12-05T12:34:56",
+                      "additionalInformation": "comment 3"
+                    }
+                  ],
+                  "additionalInformation": null
+                }
+              ],
               "history": [],
               "historyOfStatuses": [
                 {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -817,7 +817,14 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               ],
               "locations": [],
               "evidence": [],
-              "correctionRequests": [],
+              "correctionRequests": [
+                {
+                  "reason": "NOT_SPECIFIED",
+                  "descriptionOfChange": "Change 1",
+                  "correctionRequestedBy": "user2",
+                  "correctionRequestedAt": "2023-12-05T00:00:00"
+                }
+              ],
               "reportedBy": "USER1",
               "reportedDate": "2023-12-05T12:34:56",
               "status": "AWAITING_ANALYSIS",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -756,7 +756,15 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
           id = existingNomisReport.id,
           incidentReport = syncRequest.incidentReport.copy(
             incidentId = INCIDENT_NUMBER,
+            title = "Updated title",
             description = "Updated details",
+            reportingStaff = NomisStaff("OF42", 42, "Oscar", "Foxtrot"),
+            reportedDateTime = LocalDateTime.now(clock).minusDays(1),
+            status = NomisStatus("INAN", "In Analysis"),
+            questionnaireId = 419,
+            type = "ASSAULTS3",
+            incidentDateTime = LocalDateTime.now(clock).minusDays(10),
+            prison = NomisCode("FBI", "Forest Bank (HMP & YOI)"),
             staffParties = listOf(
               NomisStaffParty(reportingStaff, NomisCode("PAS", "Present at scene"), "REPORTER"),
               NomisStaffParty(
@@ -883,20 +891,20 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
              {
               "id": "${existingNomisReport.id}",
               "incidentNumber": "$INCIDENT_NUMBER",
-              "type": "SELF_HARM",
-              "incidentDateAndTime": "2023-12-05T11:34:56",
-              "prisonId": "MDI",
-              "title": "An incident occurred updated",
+              "type": "ASSAULT",
+              "incidentDateAndTime": "2023-11-25T12:34:56",
+              "prisonId": "FBI",
+              "title": "Updated title",
               "description": "Updated details",
               "event": {
                 "eventId": "$INCIDENT_NUMBER",
-                "eventDateAndTime": "2023-12-05T11:34:56",
-                "prisonId": "MDI",
-                "title": "An event occurred",
-                "description": "Details of the event",
+                "eventDateAndTime": "2023-11-25T12:34:56",
+                "prisonId": "FBI",
+                "title": "Updated title",
+                "description": "Updated details",
                 "createdDate": "2023-12-05T12:34:56",
                 "lastModifiedDate": "2023-12-05T12:34:56",
-                "lastModifiedBy": "USER1"
+                "lastModifiedBy": "OF42"
               },
               "questions": [
                 {
@@ -906,19 +914,19 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     {
                       "response": "John",
                       "recordedBy": "user2",
-                      "recordedOn": "2023-12-05T12:34:56",
+                      "recordedOn": "2023-12-04T12:34:56",
                       "additionalInformation": "comment 1"
                     },
                     {
                       "response": "Trevor",
                       "recordedBy": "user2",
-                      "recordedOn": "2023-12-05T12:34:56",
+                      "recordedOn": "2023-12-04T12:34:56",
                       "additionalInformation": "comment 2"
                     },
                     {
                       "response": "Maybe someone else?",
                       "recordedBy": "user2",
-                      "recordedOn": "2023-12-05T12:34:56",
+                      "recordedOn": "2023-12-04T12:34:56",
                       "additionalInformation": "comment 3"
                     }
                   ],
@@ -931,19 +939,19 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     {
                       "response": "Cell",
                       "recordedBy": "user2",
-                      "recordedOn": "2023-12-05T12:34:56",
+                      "recordedOn": "2023-12-04T12:34:56",
                       "additionalInformation": "comment 1"
                     },
                     {
                       "response": "Landing",
                       "recordedBy": "user2",
-                      "recordedOn": "2023-12-05T12:34:56",
+                      "recordedOn": "2023-12-04T12:34:56",
                       "additionalInformation": "comment 2"
                     },
                     {
                       "response": "Kitchen",
                       "recordedBy": "user2",
-                      "recordedOn": "2023-12-05T12:34:56",
+                      "recordedOn": "2023-12-04T12:34:56",
                       "additionalInformation": "comment 3"
                     }
                   ],
@@ -963,13 +971,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         {
                           "response": "Old answer 1",
                           "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
+                          "recordedOn": "2023-12-04T12:34:56",
                           "additionalInformation": "comment 1"
                         },
                         {
                           "response": "Old answer 2",
                           "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
+                          "recordedOn": "2023-12-04T12:34:56",
                           "additionalInformation": "comment 2"
                         }
                       ],
@@ -982,13 +990,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         {
                           "response": "Old answer 1",
                           "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
+                          "recordedOn": "2023-12-04T12:34:56",
                           "additionalInformation": "comment 1"
                         },
                         {
                           "response": "Old answer 2",
                           "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
+                          "recordedOn": "2023-12-04T12:34:56",
                           "additionalInformation": "comment 2"
                         }
                       ],
@@ -1008,13 +1016,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         {
                           "response": "Old old answer 1",
                           "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
+                          "recordedOn": "2023-12-04T12:34:56",
                           "additionalInformation": "comment 1"
                         },
                         {
                           "response": "Old old answer 2",
                           "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
+                          "recordedOn": "2023-12-04T12:34:56",
                           "additionalInformation": "comment 2"
                         }
                       ],
@@ -1027,13 +1035,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         {
                           "response": "Old old answer 1",
                           "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
+                          "recordedOn": "2023-12-04T12:34:56",
                           "additionalInformation": "comment 1"
                         },
                         {
                           "response": "Old old answer 2",
                           "recordedBy": "user2",
-                          "recordedOn": "2023-12-05T12:34:56",
+                          "recordedOn": "2023-12-04T12:34:56",
                           "additionalInformation": "comment 2"
                         }
                       ],
@@ -1049,9 +1057,9 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                   "setBy": "USER1"
                 },
                 {
-                  "status": "AWAITING_ANALYSIS",
+                  "status": "IN_ANALYSIS",
                   "setOn": "2023-12-05T12:34:56",
-                  "setBy": "user2"
+                  "setBy": "OF42"
                 }
               ],
               "staffInvolved": [
@@ -1096,13 +1104,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                   "correctionRequestedAt": "2023-11-28T00:00:00"
                 }
               ],
-              "reportedBy": "USER1",
-              "reportedDate": "2023-12-05T12:34:56",
-              "status": "AWAITING_ANALYSIS",
+              "reportedBy": "OF42",
+              "reportedDate": "2023-12-04T12:34:56",
+              "status": "IN_ANALYSIS",
               "assignedTo": "USER1",
               "createdDate": "2023-12-05T12:34:56",
               "lastModifiedDate": "2023-12-05T12:34:56",
-              "lastModifiedBy": "user2",
+              "lastModifiedBy": "OF42",
               "createdInNomis": true
             }
             """,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -757,6 +757,12 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
           incidentReport = syncRequest.incidentReport.copy(
             incidentId = INCIDENT_NUMBER,
             description = "Updated details",
+            staffParties = listOf(
+              NomisStaffParty(reportingStaff, NomisCode("PAS", "Present at scene"), "REPORTER"),
+              NomisStaffParty(
+                NomisStaff("JAMESQ", 2, "James", "Quids"),
+                NomisCode("PAS", "Present at scene"), "James was also present actually"),
+            ),
           ),
         )
         webTestClient.post().uri("/sync/upsert")
@@ -964,6 +970,11 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                   "staffUsername": "user2",
                   "staffRole": "PRESENT_AT_SCENE",
                   "comment": "REPORTER"
+                },
+                {
+                  "staffUsername": "JAMESQ",
+                  "staffRole": "PRESENT_AT_SCENE",
+                  "comment": "James was also present actually"
                 }
               ],
               "prisonersInvolved": [

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -791,6 +791,28 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               NomisRequirement("Also the description", LocalDate.now(clock), reportingStaff, "MDI"),
               NomisRequirement("Could you update the title please", LocalDate.now(clock).minusWeeks(1), reportingStaff, "MDI"),
             ),
+            questions = listOf(
+              NomisQuestion(
+                4,
+                1,
+                "Who was involved?",
+                listOf(
+                  NomisResponse(10, 1, "John", "comment 1", reportingStaff),
+                  NomisResponse(11, 2, "Trevor", "comment 2", reportingStaff),
+                  NomisResponse(12, 3, "Maybe someone else?", "comment 3", reportingStaff),
+                ),
+              ),
+              NomisQuestion(
+                5,
+                2,
+                "Where did this happen?",
+                listOf(
+                  NomisResponse(13, 1, "Cell", "comment 1", reportingStaff),
+                  NomisResponse(14, 2, "Landing", "comment 2", reportingStaff),
+                  NomisResponse(15, 3, "Kitchen", "comment 3", reportingStaff),
+                ),
+              ),
+            ),
           ),
         )
         webTestClient.post().uri("/sync/upsert")
@@ -823,22 +845,22 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               "questions": [
                 {
                   "code": "QID-000000000004",
-                  "question": "Question 1",
+                  "question": "Who was involved?",
                   "responses": [
                     {
-                      "response": "Answer 1",
+                      "response": "John",
                       "recordedBy": "user2",
                       "recordedOn": "2023-12-05T12:34:56",
                       "additionalInformation": "comment 1"
                     },
                     {
-                      "response": "Answer 2",
+                      "response": "Trevor",
                       "recordedBy": "user2",
                       "recordedOn": "2023-12-05T12:34:56",
                       "additionalInformation": "comment 2"
                     },
                     {
-                      "response": "Answer 3",
+                      "response": "Maybe someone else?",
                       "recordedBy": "user2",
                       "recordedOn": "2023-12-05T12:34:56",
                       "additionalInformation": "comment 3"
@@ -848,47 +870,22 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 },
                 {
                   "code": "QID-000000000005",
-                  "question": "Question 2",
+                  "question": "Where did this happen?",
                   "responses": [
                     {
-                      "response": "Answer 1",
+                      "response": "Cell",
                       "recordedBy": "user2",
                       "recordedOn": "2023-12-05T12:34:56",
                       "additionalInformation": "comment 1"
                     },
                     {
-                      "response": "Answer 2",
+                      "response": "Landing",
                       "recordedBy": "user2",
                       "recordedOn": "2023-12-05T12:34:56",
                       "additionalInformation": "comment 2"
                     },
                     {
-                      "response": "Answer 3",
-                      "recordedBy": "user2",
-                      "recordedOn": "2023-12-05T12:34:56",
-                      "additionalInformation": "comment 3"
-                    }
-                  ],
-                  "additionalInformation": null
-                },
-                {
-                  "code": "QID-000000000006",
-                  "question": "Question 3",
-                  "responses": [
-                    {
-                      "response": "Answer 1",
-                      "recordedBy": "user2",
-                      "recordedOn": "2023-12-05T12:34:56",
-                      "additionalInformation": "comment 1"
-                    },
-                    {
-                      "response": "Answer 2",
-                      "recordedBy": "user2",
-                      "recordedOn": "2023-12-05T12:34:56",
-                      "additionalInformation": "comment 2"
-                    },
-                    {
-                      "response": "Answer 3",
+                      "response": "Kitchen",
                       "recordedBy": "user2",
                       "recordedOn": "2023-12-05T12:34:56",
                       "additionalInformation": "comment 3"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -771,7 +771,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
              {
               "id": "${existingNomisReport.id}",
               "incidentNumber": "$INCIDENT_NUMBER",
-              "type": "FINDS",
+              "type": "SELF_HARM",
               "incidentDateAndTime": "2023-12-05T11:34:56",
               "prisonId": "MDI",
               "title": "An incident occurred updated",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -807,7 +807,14 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                   "comment": "REPORTER"
                 }
               ],
-              "prisonersInvolved": [],
+              "prisonersInvolved": [
+                {
+                  "prisonerNumber": "A1234AA",
+                  "prisonerRole": "PERPETRATOR",
+                  "outcome": "ACCT",
+                  "comment": "Comment"
+                }
+              ],
               "locations": [],
               "evidence": [],
               "correctionRequests": [],

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisCode
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisOffender
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisOffenderParty
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisRequirement
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisStaff
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisStaffParty
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisStatus
@@ -87,7 +88,19 @@ class SyncServiceTest {
           comment = "First time self-harming",
         ),
       ),
-      requirements = emptyList(),
+      requirements = listOf(
+        NomisRequirement(
+          comment = "Title should include prisoner number",
+          date = now.toLocalDate(),
+          prisonId = "MDI",
+          staff = NomisStaff(
+            staffId = 42,
+            username = "checking-user",
+            firstName = "John",
+            lastName = "McCheckin-User",
+          ),
+        ),
+      ),
       questions = emptyList(),
       history = emptyList(),
     ),
@@ -139,7 +152,7 @@ class SyncServiceTest {
     sampleReport.addCorrectionRequest(
       "checking-user",
       now,
-      CorrectionReason.MISSING_INFORMATION,
+      CorrectionReason.NOT_SPECIFIED,
       "Title should include prisoner number",
     )
   }
@@ -244,8 +257,8 @@ class SyncServiceTest {
     assertThat(report.correctionRequests).hasSize(1)
     val correctionRequest = report.correctionRequests[0]
     assertThat(correctionRequest.correctionRequestedBy).isEqualTo("checking-user")
-    assertThat(correctionRequest.correctionRequestedAt).isEqualTo(now)
-    assertThat(correctionRequest.reason).isEqualTo(CorrectionReason.MISSING_INFORMATION)
+    assertThat(correctionRequest.correctionRequestedAt.toLocalDate()).isEqualTo(now.toLocalDate())
+    assertThat(correctionRequest.reason).isEqualTo(CorrectionReason.NOT_SPECIFIED)
     assertThat(correctionRequest.descriptionOfChange).isEqualTo("Title should include prisoner number")
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
@@ -128,7 +128,7 @@ class SyncServiceTest {
     sampleReport.addQuestion("IMPL", "What implement was used?")
       .addResponse("Razor", null, reportedBy, now)
     sampleReport.addLocation("MDI-1-029", "CELL", "Wing 1, cell 029")
-    sampleReport.addStaffInvolved(StaffRole.FIRST_ON_SCENE, reportedBy)
+    sampleReport.addStaffInvolved(StaffRole.PRESENT_AT_SCENE, "user3", "Found offender in cell")
     sampleReport.addPrisonerInvolved("A1234AA", PrisonerRole.PERPETRATOR, PrisonerOutcome.SEEN_HEALTHCARE)
     sampleReport.addEvidence("CAM", "Body worn camera")
     sampleReport.addCorrectionRequest(
@@ -227,9 +227,9 @@ class SyncServiceTest {
 
     assertThat(report.staffInvolved).hasSize(1)
     val staffInvolved = report.staffInvolved[0]
-    assertThat(staffInvolved.staffUsername).isEqualTo(reportedBy)
-    assertThat(staffInvolved.staffRole).isEqualTo(StaffRole.FIRST_ON_SCENE)
-    assertThat(staffInvolved.comment).isNull()
+    assertThat(staffInvolved.staffUsername).isEqualTo("user3")
+    assertThat(staffInvolved.staffRole).isEqualTo(StaffRole.PRESENT_AT_SCENE)
+    assertThat(staffInvolved.comment).isEqualTo("Found offender in cell")
 
     assertThat(report.evidence).hasSize(1)
     val evidence = report.evidence[0]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
@@ -129,7 +129,12 @@ class SyncServiceTest {
       .addResponse("Razor", null, reportedBy, now)
     sampleReport.addLocation("MDI-1-029", "CELL", "Wing 1, cell 029")
     sampleReport.addStaffInvolved(StaffRole.PRESENT_AT_SCENE, "user3", "Found offender in cell")
-    sampleReport.addPrisonerInvolved("A1234AA", PrisonerRole.PERPETRATOR, PrisonerOutcome.SEEN_HEALTHCARE)
+    sampleReport.addPrisonerInvolved(
+      "A1234AA",
+      PrisonerRole.PERPETRATOR,
+      PrisonerOutcome.SEEN_HEALTHCARE,
+      "First time self-harming",
+    )
     sampleReport.addEvidence("CAM", "Body worn camera")
     sampleReport.addCorrectionRequest(
       "checking-user",
@@ -223,7 +228,7 @@ class SyncServiceTest {
     assertThat(prisonerInvolved.prisonerNumber).isEqualTo("A1234AA")
     assertThat(prisonerInvolved.prisonerRole).isEqualTo(PrisonerRole.PERPETRATOR)
     assertThat(prisonerInvolved.outcome).isEqualTo(PrisonerOutcome.SEEN_HEALTHCARE)
-    assertThat(prisonerInvolved.comment).isNull()
+    assertThat(prisonerInvolved.comment).isEqualTo("First time self-harming")
 
     assertThat(report.staffInvolved).hasSize(1)
     val staffInvolved = report.staffInvolved[0]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
@@ -24,8 +24,10 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisCode
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisOffender
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisOffenderParty
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisQuestion
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisRequirement
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisResponse
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisStaff
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisStaffParty
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisStatus
@@ -101,7 +103,27 @@ class SyncServiceTest {
           ),
         ),
       ),
-      questions = emptyList(),
+      questions = listOf(
+        NomisQuestion(
+          questionId = 42,
+          sequence = 1,
+          question = "What implement was used?",
+          answers = listOf(
+            NomisResponse(
+              answer = "Razor",
+              questionResponseId = null,
+              sequence = 1,
+              comment = null,
+              recordingStaff = NomisStaff(
+                username = reportedBy,
+                staffId = 42,
+                firstName = "John",
+                lastName = "Doe",
+              ),
+            ),
+          ),
+        ),
+      ),
       history = emptyList(),
     ),
   )
@@ -138,7 +160,7 @@ class SyncServiceTest {
   )
 
   init {
-    sampleReport.addQuestion("IMPL", "What implement was used?")
+    sampleReport.addQuestion("QID-000000000042", "What implement was used?")
       .addResponse("Razor", null, reportedBy, now)
     sampleReport.addLocation("MDI-1-029", "CELL", "Wing 1, cell 029")
     sampleReport.addStaffInvolved(StaffRole.PRESENT_AT_SCENE, "user3", "Found offender in cell")
@@ -220,7 +242,7 @@ class SyncServiceTest {
 
     assertThat(report.questions).hasSize(1)
     val question = report.questions[0]
-    assertThat(question.code).isEqualTo("IMPL")
+    assertThat(question.code).isEqualTo("QID-000000000042")
     assertThat(question.question).isEqualTo("What implement was used?")
     assertThat(question.additionalInformation).isNull()
     assertThat(question.responses).hasSize(1)


### PR DESCRIPTION
Report is now updated with information provided in sync request:
- type
- staff involvement
- prisoners involvement
- correction requests (called "requirements" in the NOMIS sync request)
- questions/answers
- history

Logic is very similar to one in Mapping. That's why I've extracted it into extension functions that they're reused in the (JPA) `Report`'s `updateWith()` method.
The main difference is that the `updateWith()` method _**clears**_ the associated records before adding whatever is provided by the sync request (using the `Mapping.kt` extensions function.