### PR TITLE
IR-234: Add paginated endpoint to return all reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/SimplePage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/SimplePage.kt
@@ -28,8 +28,8 @@ class SimplePage<T>(
   sort: Sort,
 ) : PageImpl<T>(content, PageRequest.of(number, size, sort), totalElements) {
   @get:Schema(description = "Sort orders", example = "[\"property,ASC\"]")
-  @get:JsonProperty
-  val sort: List<String>
+  @get:JsonProperty("sort")
+  val sortOrderList: List<String>
     get() {
       return pageable.sort.stream().map { "${it.property},${it.direction}" }.toList()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/SimplePage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/SimplePage.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto.response
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+
+/**
+ * A `org.springframework.data.domain.Page` that serialises better than the default implementation.
+ * Removes excessive and redundant properties.
+ */
+@JsonIgnoreProperties(
+  value = [
+    "pageable",
+    "first",
+    "last",
+    "empty",
+  ],
+)
+class SimplePage<T>(
+  content: List<T>,
+  totalElements: Long,
+  number: Int,
+  size: Int,
+  sort: Sort,
+) : PageImpl<T>(content, PageRequest.of(number, size, sort), totalElements) {
+  @get:Schema(description = "Sort orders", example = "[\"property,ASC\"]")
+  @get:JsonProperty
+  val sort: List<String>
+    get() {
+      return pageable.sort.stream().map { "${it.property},${it.direction}" }.toList()
+    }
+}
+
+fun <T> Page<T>.toSimplePage(): SimplePage<T> = SimplePage(content, totalElements, pageable.pageNumber, pageable.pageSize, sort)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ApiExceptionHandler.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.incidentreporting.resource
 import jakarta.validation.ValidationException
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
+import org.springframework.data.mapping.PropertyReferenceException
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
@@ -28,6 +29,7 @@ class ApiExceptionHandler {
       .body(
         ErrorResponse(
           status = BAD_REQUEST,
+          errorCode = ErrorCode.ValidationFailure,
           userMessage = "Validation failure: ${e.message}",
           developerMessage = e.message,
         ),
@@ -56,6 +58,7 @@ class ApiExceptionHandler {
       .body(
         ErrorResponse(
           status = BAD_REQUEST,
+          errorCode = ErrorCode.ValidationFailure,
           userMessage = "Validation failure: Couldn't read request body: ${e.message}",
           developerMessage = e.message,
         ),
@@ -77,6 +80,7 @@ class ApiExceptionHandler {
       .body(
         ErrorResponse(
           status = BAD_REQUEST,
+          errorCode = ErrorCode.ValidationFailure,
           userMessage = "Validation failure: $message",
           developerMessage = e.message,
         ),
@@ -157,6 +161,22 @@ class ApiExceptionHandler {
   @ExceptionHandler(MethodArgumentNotValidException::class)
   fun handleInvalidMethodArgumentException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse>? {
     log.debug("MethodArgumentNotValidException exception caught: {}", e.message)
+
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          errorCode = ErrorCode.ValidationFailure,
+          userMessage = "Validation Failure: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(PropertyReferenceException::class)
+  fun handlePropertyReferenceException(e: PropertyReferenceException): ResponseEntity<ErrorResponse>? {
+    log.debug("PropertyReferenceException caught: {}", e.message)
 
     return ResponseEntity
       .status(BAD_REQUEST)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.ValidationException
 import org.springdoc.core.annotations.ParameterObject
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
@@ -24,6 +23,8 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.CreateReportRequest
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.SimplePage
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.toSimplePage
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportDomainEventType
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportService
 import java.util.UUID
@@ -71,11 +72,12 @@ class ReportResource(
     @ParameterObject
     @PageableDefault(page = 0, size = 20, sort = ["incidentDateAndTime"], direction = Sort.Direction.DESC)
     pageable: Pageable,
-  ): Page<ReportDto> {
+  ): SimplePage<ReportDto> {
     if (pageable.pageSize > 50) {
       throw ValidationException("Page size must be 50 or less")
     }
     return reportService.getReports(pageable)
+      .toSimplePage()
   }
 
   @GetMapping("/{id}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -4,6 +4,10 @@ import com.microsoft.applicationinsights.TelemetryClient
 import jakarta.validation.ValidationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.incidentreporting.config.AuthenticationFacade
@@ -29,6 +33,13 @@ class ReportService(
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getReports(
+    pageable: Pageable = PageRequest.of(0, 20, Sort.by("incidentDateAndTime").descending()),
+  ): Page<ReportDto> {
+    return reportRepository.findAll(pageable)
+      .map { it.toDto() }
   }
 
   fun getReportById(id: UUID): ReportDto? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -185,6 +185,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
       ),
     )
 
+    @DisplayName("is secured")
     @Nested
     inner class Security {
       @Test
@@ -225,6 +226,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
       }
     }
 
+    @DisplayName("validates requests")
     @Nested
     inner class Validation {
       @Test
@@ -238,6 +240,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
       }
     }
 
+    @DisplayName("works")
     @Nested
     inner class HappyPath {
       @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -126,9 +126,10 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "size": 20,
               "numberOfElements": 0,
               "totalElements": 0,
-              "totalPages": 0
+              "totalPages": 0,
+              "sort": ["incidentDateAndTime,DESC"]
             }""",
-            false,
+            true,
           )
       }
 
@@ -155,7 +156,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "size": 20,
               "numberOfElements": 1,
               "totalElements": 1,
-              "totalPages": 1
+              "totalPages": 1,
+              "sort": ["incidentDateAndTime,DESC"]
             }""",
             false,
           )
@@ -239,7 +241,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                 "size": 20,
                 "numberOfElements": 5,
                 "totalElements": 5,
-                "totalPages": 1
+                "totalPages": 1,
+                "sort": ["incidentDateAndTime,DESC"]
               }""",
               false,
             )
@@ -277,7 +280,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                 "size": 2,
                 "numberOfElements": 2,
                 "totalElements": 5,
-                "totalPages": 3
+                "totalPages": 3,
+                "sort": ["incidentDateAndTime,DESC"]
               }""",
               false,
             )
@@ -315,7 +319,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                 "size": 2,
                 "numberOfElements": 2,
                 "totalElements": 5,
-                "totalPages": 3
+                "totalPages": 3,
+                "sort": ["incidentDateAndTime,DESC"]
               }""",
               false,
             )
@@ -350,7 +355,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                 "size": 20,
                 "numberOfElements": 5,
                 "totalElements": 5,
-                "totalPages": 1
+                "totalPages": 1,
+                "sort": ["$sortParam"]
               }""",
               false,
             ).jsonPath("content[*].incidentNumber")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -100,6 +100,18 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             assertThat(it).contains("Page size must be")
           }
       }
+
+      @Test
+      fun `cannot sort by invalid property`() {
+        webTestClient.get().uri("$url?sort=missing,DESC")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isBadRequest
+          .expectBody().jsonPath("developerMessage").value<String> {
+            assertThat(it).contains("No property 'missing' found for type 'Report'")
+          }
+      }
     }
 
     @DisplayName("works")


### PR DESCRIPTION
Filtering is not currently supported, but this will still be useful for periodic jobs to reconcile reports against NOMIS.