### PR TITLE
IR-236: Replace UUID generation with v7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,11 +27,11 @@ dependencies {
   implementation("org.flywaydb:flyway-core")
   implementation("com.zaxxer:HikariCP:5.1.0")
   runtimeOnly("org.postgresql:postgresql:42.7.3")
-  implementation("com.github.f4b6a3:uuid-creator:5.3.7")
 
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.1")
+  implementation("com.fasterxml.uuid:java-uuid-generator:5.0.0")
 
   implementation("com.pauldijou:jwt-core_2.11:5.0.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   implementation("org.flywaydb:flyway-core")
   implementation("com.zaxxer:HikariCP:5.1.0")
   runtimeOnly("org.postgresql:postgresql:42.7.3")
+  implementation("com.github.f4b6a3:uuid-creator:5.3.7")
 
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.id.UuidV7Generator
 import java.time.Clock
 import java.time.LocalDateTime
 import java.util.UUID
@@ -31,7 +32,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.Report as ReportDto
 class Report(
   @Id
   @GeneratedValue(generator = "UUID")
-  @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+  @GenericGenerator(name = "UUID", type = UuidV7Generator::class)
   @Column(name = "id", updatable = false, nullable = false)
   val id: UUID? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/id/UuidV7Generator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/id/UuidV7Generator.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.jpa.id
 
-import com.github.f4b6a3.uuid.UuidCreator
+import com.fasterxml.uuid.Generators
+import com.fasterxml.uuid.NoArgGenerator
 import org.hibernate.engine.spi.SharedSessionContractImplementor
 import org.hibernate.generator.BeforeExecutionGenerator
 import org.hibernate.generator.EventType
@@ -9,6 +10,10 @@ import java.util.EnumSet
 import java.util.UUID
 
 class UuidV7Generator : BeforeExecutionGenerator {
+  companion object {
+    val uuidGenerator: NoArgGenerator = Generators.timeBasedEpochGenerator(null)
+  }
+
   override fun getEventTypes(): EnumSet<EventType> {
     return INSERT_ONLY
   }
@@ -19,7 +24,7 @@ class UuidV7Generator : BeforeExecutionGenerator {
     currentValue: Any?,
     eventType: EventType?,
   ): UUID {
-    // NB: the default `org.hibernate.id.uuid.UuidGenerator` ignores session, owner, currentValue and eventType
-    return UuidCreator.getTimeOrderedEpoch()
+    // NB: the default `org.hibernate.id.uuid.UuidGenerator` also ignores session, owner, currentValue and eventType
+    return uuidGenerator.generate()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/id/UuidV7Generator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/id/UuidV7Generator.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.jpa.id
+
+import com.github.f4b6a3.uuid.UuidCreator
+import org.hibernate.engine.spi.SharedSessionContractImplementor
+import org.hibernate.generator.BeforeExecutionGenerator
+import org.hibernate.generator.EventType
+import org.hibernate.generator.EventTypeSets.INSERT_ONLY
+import java.util.EnumSet
+import java.util.UUID
+
+class UuidV7Generator : BeforeExecutionGenerator {
+  override fun getEventTypes(): EnumSet<EventType> {
+    return INSERT_ONLY
+  }
+
+  override fun generate(
+    session: SharedSessionContractImplementor?,
+    owner: Any?,
+    currentValue: Any?,
+    eventType: EventType?,
+  ): UUID {
+    // NB: the default `org.hibernate.id.uuid.UuidGenerator` ignores session, owner, currentValue and eventType
+    return UuidCreator.getTimeOrderedEpoch()
+  }
+}

--- a/src/main/resources/db/migration/V1_1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1_1__initial_schema.sql
@@ -21,7 +21,7 @@ create table event
 
 create table report
 (
-    id                     uuid       default gen_random_uuid() not null
+    id                     uuid                                 not null
         constraint report_pk primary key,
     event_id               integer                              not null
         constraint report_event_fk references event (id) on delete restrict,


### PR DESCRIPTION
…to have report primary keys be (almost certainly) lexicographically sequential. This will enable sorting reports in the database using the `id` column and retaining a stable order.

Note that:
• the current `org.hibernate.id.UUIDGenerator` is deprecated anyway
• and the suggested replacement `org.hibernate.id.uuid.UuidGenerator` only supports UUID v1 and v4
• deployed databases will need to be cleared prior to merging