### PR TITLE
IR-240: Filter reports by prison, source, status and type as well as when incidents took place or were reported 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
@@ -106,8 +106,8 @@ fun Report.addNomisQuestions(questions: Collection<NomisQuestion>) {
   }
 }
 
-fun Report.addNomisHistory(history: Collection<NomisHistory>) {
-  history.forEach { history ->
+fun Report.addNomisHistory(histories: Collection<NomisHistory>) {
+  histories.forEach { history ->
     val historyRecord = this.addHistory(
       type = Type.fromNomisCode(history.type),
       incidentChangeDate = history.incidentChangeDate.atStartOfDay(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -53,15 +53,16 @@ class Report(
   var prisonId: String,
 
   @Enumerated(EnumType.STRING)
-  private var type: Type,
+  var type: Type,
+
+  @Enumerated(EnumType.STRING)
+  var status: Status = Status.DRAFT,
 
   var title: String,
   var description: String,
 
   var reportedBy: String,
   var reportedDate: LocalDateTime,
-  @Enumerated(EnumType.STRING)
-  var status: Status = Status.DRAFT,
 
   @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], optional = false)
   val event: Event,
@@ -109,8 +110,6 @@ class Report(
   }
 
   fun getQuestions(): List<Question> = questions
-
-  fun getType() = type
 
   fun changeType(newType: Type, changedDate: LocalDateTime, staffChanged: String): Report {
     copyToHistory(changedDate, staffChanged)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -58,6 +58,9 @@ class Report(
   @Enumerated(EnumType.STRING)
   var status: Status = Status.DRAFT,
 
+  @Enumerated(EnumType.STRING)
+  val source: InformationSource = InformationSource.DPS,
+
   var title: String,
   var description: String,
 
@@ -97,9 +100,6 @@ class Report(
   @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @OrderBy("change_date ASC")
   val history: MutableList<History> = mutableListOf(),
-
-  @Enumerated(EnumType.STRING)
-  val source: InformationSource = InformationSource.DPS,
 
   val createdDate: LocalDateTime,
   var lastModifiedDate: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/ReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/ReportRepository.kt
@@ -1,13 +1,14 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 import java.util.UUID
 
 @Repository
-interface ReportRepository : JpaRepository<Report, UUID> {
+interface ReportRepository : JpaRepository<Report, UUID>, JpaSpecificationExecutor<Report> {
   fun findOneByIncidentNumber(incidentNumber: String): Report?
 
   @Query(value = "SELECT nextval('report_sequence')", nativeQuery = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications
+
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Root
+import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
+
+fun filterByPrisonId(prisonId: String): Specification<Report> {
+  return Specification { root: Root<Report>, _: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+    criteriaBuilder.equal(root.get<String>(Report::prisonId.name), prisonId)
+  }
+}
+
+fun filterBySource(informationSource: InformationSource): Specification<Report> {
+  return Specification { root: Root<Report>, _: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+    criteriaBuilder.equal(root.get<InformationSource>(Report::source.name), informationSource)
+  }
+}
+
+fun filterByStatus(status: Status): Specification<Report> {
+  return Specification { root: Root<Report>, _: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+    criteriaBuilder.equal(root.get<Status>(Report::status.name), status)
+  }
+}
+
+fun filterByType(type: Type): Specification<Report> {
+  return Specification { root: Root<Report>, _: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+    criteriaBuilder.equal(root.get<Type>(Report::type.name), type)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications
 
-import jakarta.persistence.criteria.CriteriaBuilder
-import jakarta.persistence.criteria.CriteriaQuery
-import jakarta.persistence.criteria.Root
 import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
@@ -10,25 +7,25 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 
 fun filterByPrisonId(prisonId: String): Specification<Report> {
-  return Specification { root: Root<Report>, _: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+  return Specification { root, _, criteriaBuilder ->
     criteriaBuilder.equal(root.get<String>(Report::prisonId.name), prisonId)
   }
 }
 
 fun filterBySource(informationSource: InformationSource): Specification<Report> {
-  return Specification { root: Root<Report>, _: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+  return Specification { root, _, criteriaBuilder ->
     criteriaBuilder.equal(root.get<InformationSource>(Report::source.name), informationSource)
   }
 }
 
 fun filterByStatus(status: Status): Specification<Report> {
-  return Specification { root: Root<Report>, _: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+  return Specification { root, _, criteriaBuilder ->
     criteriaBuilder.equal(root.get<Status>(Report::status.name), status)
   }
 }
 
 fun filterByType(type: Type): Specification<Report> {
-  return Specification { root: Root<Report>, _: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder ->
+  return Specification { root, _, criteriaBuilder ->
     criteriaBuilder.equal(root.get<Type>(Report::type.name), type)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSourc
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
+import java.time.LocalDate
 
 fun filterByPrisonId(prisonId: String) = Report::prisonId.buildSpecForEqualTo(prisonId)
 
@@ -12,3 +13,15 @@ fun filterBySource(informationSource: InformationSource) = Report::source.buildS
 fun filterByStatus(status: Status) = Report::status.buildSpecForEqualTo(status)
 
 fun filterByType(type: Type) = Report::type.buildSpecForEqualTo(type)
+
+fun filterByIncidentDateFrom(date: LocalDate) =
+  Report::incidentDateAndTime.buildSpecForGreaterThanOrEqualTo(date.atStartOfDay())
+
+fun filterByIncidentDateUntil(date: LocalDate) =
+  Report::incidentDateAndTime.buildSpecForLessThan(date.plusDays(1).atStartOfDay())
+
+fun filterByReportedDateFrom(date: LocalDate) =
+  Report::reportedDate.buildSpecForGreaterThanOrEqualTo(date.atStartOfDay())
+
+fun filterByReportedDateUntil(date: LocalDate) =
+  Report::reportedDate.buildSpecForLessThan(date.plusDays(1).atStartOfDay())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
@@ -1,31 +1,14 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications
 
-import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 
-fun filterByPrisonId(prisonId: String): Specification<Report> {
-  return Specification { root, _, criteriaBuilder ->
-    criteriaBuilder.equal(root.get<String>(Report::prisonId.name), prisonId)
-  }
-}
+fun filterByPrisonId(prisonId: String) = Report::prisonId.buildSpecForEqualTo(prisonId)
 
-fun filterBySource(informationSource: InformationSource): Specification<Report> {
-  return Specification { root, _, criteriaBuilder ->
-    criteriaBuilder.equal(root.get<InformationSource>(Report::source.name), informationSource)
-  }
-}
+fun filterBySource(informationSource: InformationSource) = Report::source.buildSpecForEqualTo(informationSource)
 
-fun filterByStatus(status: Status): Specification<Report> {
-  return Specification { root, _, criteriaBuilder ->
-    criteriaBuilder.equal(root.get<Status>(Report::status.name), status)
-  }
-}
+fun filterByStatus(status: Status) = Report::status.buildSpecForEqualTo(status)
 
-fun filterByType(type: Type): Specification<Report> {
-  return Specification { root, _, criteriaBuilder ->
-    criteriaBuilder.equal(root.get<Type>(Report::type.name), type)
-  }
-}
+fun filterByType(type: Type) = Report::type.buildSpecForEqualTo(type)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/Specifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/Specifications.kt
@@ -3,9 +3,37 @@ package uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications
 import org.springframework.data.jpa.domain.Specification
 import kotlin.reflect.KProperty1
 
-/** Creates an equality specification from an entity’s property */
+/** Build «equal to» specification from an entity’s property */
 fun <T, V> KProperty1<T, V>.buildSpecForEqualTo(value: V): Specification<T> {
   return Specification { root, _, criteriaBuilder ->
     criteriaBuilder.equal(root.get<V>(name), value)
+  }
+}
+
+/** Build «less than» specification from an entity’s property */
+fun <T, V : Comparable<V>> KProperty1<T, V>.buildSpecForLessThan(value: V): Specification<T> {
+  return Specification { root, _, criteriaBuilder ->
+    criteriaBuilder.lessThan(root.get(name), value)
+  }
+}
+
+/** Build «less than or equal to» specification from an entity’s property */
+fun <T, V : Comparable<V>> KProperty1<T, V>.buildSpecForLessThanOrEqualTo(value: V): Specification<T> {
+  return Specification { root, _, criteriaBuilder ->
+    criteriaBuilder.lessThanOrEqualTo(root.get(name), value)
+  }
+}
+
+/** Build «greater than» specification from an entity’s property */
+fun <T, V : Comparable<V>> KProperty1<T, V>.buildSpecForGreaterThan(value: V): Specification<T> {
+  return Specification { root, _, criteriaBuilder ->
+    criteriaBuilder.greaterThan(root.get(name), value)
+  }
+}
+
+/** Build «greater than or equal to» specification from an entity’s property */
+fun <T, V : Comparable<V>> KProperty1<T, V>.buildSpecForGreaterThanOrEqualTo(value: V): Specification<T> {
+  return Specification { root, _, criteriaBuilder ->
+    criteriaBuilder.greaterThanOrEqualTo(root.get(name), value)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/Specifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/Specifications.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications
+
+import org.springframework.data.jpa.domain.Specification
+import kotlin.reflect.KProperty1
+
+/** Creates an equality specification from an entity’s property */
+fun <T, V> KProperty1<T, V>.buildSpecForEqualTo(value: V): Specification<T> {
+  return Specification { root, _, criteriaBuilder ->
+    criteriaBuilder.equal(root.get<V>(name), value)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.ValidationException
+import jakarta.validation.constraints.Size
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
@@ -19,9 +20,12 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.CreateReportRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.SimplePage
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.toSimplePage
@@ -44,7 +48,7 @@ class ReportResource(
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
   @Operation(
-    summary = "Returns pages of incident reports",
+    summary = "Returns pages of filtered incident reports",
     description = "Requires role VIEW_INCIDENT_REPORTS",
     responses = [
       ApiResponse(
@@ -69,6 +73,40 @@ class ReportResource(
     ],
   )
   fun getReports(
+    @Schema(
+      description = "Filter by given prison ID",
+      required = false,
+      defaultValue = "null",
+      example = "MDI",
+      minLength = 2,
+    )
+    @RequestParam(required = false)
+    @Size(min = 2)
+    prisonId: String? = null,
+    @Schema(
+      description = "Filter by given information source",
+      required = false,
+      defaultValue = "null",
+      example = "DPS",
+    )
+    @RequestParam(required = false)
+    source: InformationSource? = null,
+    @Schema(
+      description = "Filter by given status",
+      required = false,
+      defaultValue = "null",
+      example = "IN_ANALYSIS",
+    )
+    @RequestParam(required = false)
+    status: Status? = null,
+    @Schema(
+      description = "Filter by given incident type",
+      required = false,
+      defaultValue = "null",
+      example = "DAMAGE",
+    )
+    @RequestParam(required = false)
+    type: Type? = null,
     @ParameterObject
     @PageableDefault(page = 0, size = 20, sort = ["incidentDateAndTime"], direction = Sort.Direction.DESC)
     pageable: Pageable,
@@ -76,7 +114,13 @@ class ReportResource(
     if (pageable.pageSize > 50) {
       throw ValidationException("Page size must be 50 or less")
     }
-    return reportService.getReports(pageable)
+    return reportService.getReports(
+      prisonId = prisonId,
+      source = source,
+      status = status,
+      type = type,
+      pageable = pageable,
+    )
       .toSimplePage()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -81,7 +81,7 @@ class ReportResource(
       minLength = 2,
     )
     @RequestParam(required = false)
-    @Size(min = 2)
+    @Size(min = 2, max = 10)
     prisonId: String? = null,
     @Schema(
       description = "Filter by given information source",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.SimplePage
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.toSimplePage
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportDomainEventType
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportService
+import java.time.LocalDate
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Report as ReportDto
 
@@ -79,6 +80,7 @@ class ReportResource(
       defaultValue = "null",
       example = "MDI",
       minLength = 2,
+      maxLength = 10,
     )
     @RequestParam(required = false)
     @Size(min = 2, max = 10)
@@ -107,6 +109,38 @@ class ReportResource(
     )
     @RequestParam(required = false)
     type: Type? = null,
+    @Schema(
+      description = "Filter for incidents occurring since this date (inclusive)",
+      required = false,
+      defaultValue = "null",
+      example = "2024-01-01",
+    )
+    @RequestParam(required = false)
+    incidentDateFrom: LocalDate? = null,
+    @Schema(
+      description = "Filter for incidents occurring until this date (inclusive)",
+      required = false,
+      defaultValue = "null",
+      example = "2024-05-31",
+    )
+    @RequestParam(required = false)
+    incidentDateUntil: LocalDate? = null,
+    @Schema(
+      description = "Filter for incidents reported since this date (inclusive)",
+      required = false,
+      defaultValue = "null",
+      example = "2024-01-01",
+    )
+    @RequestParam(required = false)
+    reportedDateFrom: LocalDate? = null,
+    @Schema(
+      description = "Filter for incidents reported until this date (inclusive)",
+      required = false,
+      defaultValue = "null",
+      example = "2024-05-31",
+    )
+    @RequestParam(required = false)
+    reportedDateUntil: LocalDate? = null,
     @ParameterObject
     @PageableDefault(page = 0, size = 20, sort = ["incidentDateAndTime"], direction = Sort.Direction.DESC)
     pageable: Pageable,
@@ -119,6 +153,10 @@ class ReportResource(
       source = source,
       status = status,
       type = type,
+      incidentDateFrom = incidentDateFrom,
+      incidentDateUntil = incidentDateUntil,
+      reportedDateFrom = reportedDateFrom,
+      reportedDateUntil = reportedDateUntil,
       pageable = pageable,
     )
       .toSimplePage()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -8,14 +8,22 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.incidentreporting.config.AuthenticationFacade
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.CreateReportRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateEventId
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateIncidentNumber
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByPrisonId
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterBySource
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByStatus
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByType
 import uk.gov.justice.digital.hmpps.incidentreporting.resource.EventNotFoundException
 import java.time.Clock
 import java.util.UUID
@@ -36,9 +44,21 @@ class ReportService(
   }
 
   fun getReports(
+    prisonId: String? = null,
+    source: InformationSource? = null,
+    status: Status? = null,
+    type: Type? = null,
     pageable: Pageable = PageRequest.of(0, 20, Sort.by("incidentDateAndTime").descending()),
   ): Page<ReportDto> {
-    return reportRepository.findAll(pageable)
+    val specification = Specification.allOf(
+      buildList {
+        prisonId?.let { add(filterByPrisonId(prisonId)) }
+        source?.let { add(filterBySource(source)) }
+        status?.let { add(filterByStatus(status)) }
+        type?.let { add(filterByType(type)) }
+      },
+    )
+    return reportRepository.findAll(specification, pageable)
       .map { it.toDto() }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -20,12 +20,17 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventReposi
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateEventId
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateIncidentNumber
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateFrom
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateUntil
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByPrisonId
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByReportedDateFrom
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByReportedDateUntil
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterBySource
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByStatus
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByType
 import uk.gov.justice.digital.hmpps.incidentreporting.resource.EventNotFoundException
 import java.time.Clock
+import java.time.LocalDate
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Report as ReportDto
@@ -48,6 +53,10 @@ class ReportService(
     source: InformationSource? = null,
     status: Status? = null,
     type: Type? = null,
+    incidentDateFrom: LocalDate? = null,
+    incidentDateUntil: LocalDate? = null,
+    reportedDateFrom: LocalDate? = null,
+    reportedDateUntil: LocalDate? = null,
     pageable: Pageable = PageRequest.of(0, 20, Sort.by("incidentDateAndTime").descending()),
   ): Page<ReportDto> {
     val specification = Specification.allOf(
@@ -56,6 +65,10 @@ class ReportService(
         source?.let { add(filterBySource(source)) }
         status?.let { add(filterByStatus(status)) }
         type?.let { add(filterByType(type)) }
+        incidentDateFrom?.let { add(filterByIncidentDateFrom(incidentDateFrom)) }
+        incidentDateUntil?.let { add(filterByIncidentDateUntil(incidentDateUntil)) }
+        reportedDateFrom?.let { add(filterByReportedDateFrom(reportedDateFrom)) }
+        reportedDateUntil?.let { add(filterByReportedDateUntil(reportedDateUntil)) }
       },
     )
     return reportRepository.findAll(specification, pageable)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/IncidentReportBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/IncidentReportBuilder.kt
@@ -1,24 +1,28 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.helper
 
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Event
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 import java.time.LocalDateTime
 
 fun buildIncidentReport(
+  incidentNumber: String,
+  reportTime: LocalDateTime,
+  prisonId: String = "MDI",
+  source: InformationSource = InformationSource.DPS,
+  status: Status = Status.DRAFT,
   type: Type = Type.FINDS,
   reportingUsername: String = "USER1",
-  prisonId: String = "MDI",
-  reportTime: LocalDateTime,
-  incidentNumber: String,
-  source: InformationSource = InformationSource.DPS,
 ): Report {
   val eventDateAndTime = reportTime.minusHours(1)
   val report = Report(
     incidentNumber = incidentNumber,
-    prisonId = prisonId,
     incidentDateAndTime = eventDateAndTime,
+    prisonId = prisonId,
+    source = source,
+    status = status,
     type = type,
     title = "Incident Report $incidentNumber",
     description = "A new incident created in the new service of type ${type.description}",
@@ -28,7 +32,6 @@ fun buildIncidentReport(
     reportedBy = reportingUsername,
     assignedTo = reportingUsername,
     lastModifiedBy = reportingUsername,
-    source = source,
     event = Event(
       eventId = when (source) {
         InformationSource.DPS -> "IE-${incidentNumber.removePrefix("IR-")}"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -25,7 +25,11 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventReposi
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateEventId
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateIncidentNumber
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateFrom
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateUntil
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByPrisonId
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByReportedDateFrom
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByReportedDateUntil
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterBySource
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByStatus
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByType
@@ -74,6 +78,10 @@ class ReportRepositoryTest : IntegrationTestBase() {
         filterBySource(InformationSource.DPS),
         filterByStatus(Status.DRAFT),
         filterByType(Type.FINDS),
+        filterByIncidentDateFrom(now.toLocalDate().minusDays(2)),
+        filterByIncidentDateUntil(now.toLocalDate()),
+        filterByReportedDateFrom(now.toLocalDate().minusDays(2)),
+        filterByReportedDateUntil(now.toLocalDate()),
       )
       matchingSpecifications.forEach { specification ->
         val reportsFound = reportRepository.findAll(
@@ -89,6 +97,10 @@ class ReportRepositoryTest : IntegrationTestBase() {
         filterBySource(InformationSource.NOMIS),
         filterByStatus(Status.AWAITING_ANALYSIS),
         filterByType(Type.FOOD_REFUSAL),
+        filterByIncidentDateFrom(now.toLocalDate()),
+        filterByIncidentDateUntil(now.toLocalDate().minusDays(2)),
+        filterByReportedDateFrom(now.toLocalDate()),
+        filterByReportedDateUntil(now.toLocalDate().minusDays(2)),
       )
       nonMatchingSpecifications.forEach { specification ->
         val reportsFound = reportRepository.findAll(
@@ -178,6 +190,17 @@ class ReportRepositoryTest : IntegrationTestBase() {
           .and(filterBySource(InformationSource.DPS))
           .and(filterByPrisonId("MDI"))
           .and(filterByType(Type.FINDS)),
+        emptyList(),
+      )
+      assertSpecificationReturnsReports(
+        filterByIncidentDateFrom(now.toLocalDate().minusDays(3))
+          .and(filterByIncidentDateUntil(now.toLocalDate().minusDays(3)))
+          .and(filterByType(Type.ASSAULT)),
+        listOf(report1Id),
+      )
+      assertSpecificationReturnsReports(
+        filterByReportedDateFrom(now.toLocalDate().minusDays(4))
+          .and(filterByReportedDateUntil(now.toLocalDate().minusDays(4))),
         emptyList(),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -126,7 +126,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
 
     report = reportRepository.findOneByIncidentNumber(report.incidentNumber) ?: throw EntityNotFoundException()
     assertThat(report.status).isEqualTo(Status.AWAITING_ANALYSIS)
-    assertThat(report.getType()).isEqualTo(Type.ASSAULT)
+    assertThat(report.type).isEqualTo(Type.ASSAULT)
     assertThat(report.getQuestions()).hasSize(1)
     assertThat(report.getQuestions()[0].code).isEqualTo("SOME_QUESTION")
     assertThat(report.getQuestions()[0].getResponses()).hasSize(4)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -6,12 +6,14 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.CreateReportRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.helper.buildIncidentReport
@@ -181,20 +183,21 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         @BeforeEach
         fun setUp() {
           // makes an additional 4 older reports, 2 of which are from NOMIS
-          listOf("IR-0000000001017203", "IR-0000000001006603", "94728", "31934")
-            .forEachIndexed { daysBefore, incidentNumber ->
-              reportRepository.save(
+          reportRepository.saveAll(
+            listOf("IR-0000000001017203", "IR-0000000001006603", "94728", "31934")
+              .mapIndexed { index, incidentNumber ->
+                val fromDps = incidentNumber.startsWith("IR-")
+                val daysBefore = index.toLong() + 1
                 buildIncidentReport(
                   incidentNumber = incidentNumber,
-                  reportTime = LocalDateTime.now(clock).minusDays(daysBefore.toLong() + 1),
-                  source = if (incidentNumber.startsWith("IR-")) {
-                    InformationSource.DPS
-                  } else {
-                    InformationSource.NOMIS
-                  },
-                ),
-              )
-            }
+                  reportTime = LocalDateTime.now(clock).minusDays(daysBefore),
+                  prisonId = if (index < 2) "LEI" else "MDI",
+                  status = if (fromDps) Status.DRAFT else Status.AWAITING_ANALYSIS,
+                  source = if (fromDps) InformationSource.DPS else InformationSource.NOMIS,
+                  type = if (index < 3) Type.FINDS else Type.FIRE,
+                )
+              },
+          )
         }
 
         @Test
@@ -380,6 +383,31 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             .value<List<String>> {
               assertThat(it).isEqualTo(expectedIncidentNumbers)
             }
+        }
+
+        @ParameterizedTest(name = "can filter reports by `{0}`")
+        @CsvSource(
+          value = [
+            "'',                        5",
+            "prisonId=MDI,              3",
+            "status=DRAFT,              3",
+            "source=DPS,                3",
+            "source=NOMIS,              2",
+            "source=NOMIS&prisonId=MDI, 2",
+            "source=DPS&prisonId=MDI,   1",
+            "type=ASSAULT,              0",
+            "type=FIRE,                 1",
+            "type=FIRE&prisonId=LEI,    0",
+            "type=FIRE&prisonId=MDI,    1",
+          ],
+        )
+        fun `can filter reports`(params: String, count: Int) {
+          webTestClient.get().uri("$url?$params")
+            .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
+            .header("Content-Type", "application/json")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody().jsonPath("totalElements").isEqualTo(count)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -114,6 +114,25 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             assertThat(it).contains("No property 'missing' found for type 'Report'")
           }
       }
+
+      @ParameterizedTest(name = "cannot filter by invalid `{0}`")
+      @ValueSource(
+        strings = [
+          "prisonId=",
+          "prisonId=M",
+          "prisonId=Moorland+(HMP)",
+          "source=nomis",
+          "status=new",
+          "type=ABSCOND",
+        ],
+      )
+      fun `cannot filter by invalid property`(param: String) {
+        webTestClient.get().uri("$url?$param")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isBadRequest
+      }
     }
 
     @DisplayName("works")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -124,6 +124,9 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           "source=nomis",
           "status=new",
           "type=ABSCOND",
+          "incidentDateFrom=2024",
+          "incidentDateUntil=yesterday",
+          "reportedDateFrom=1%2F1%2F2020",
         ],
       )
       fun `cannot filter by invalid property`(param: String) {
@@ -407,17 +410,23 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         @ParameterizedTest(name = "can filter reports by `{0}`")
         @CsvSource(
           value = [
-            "'',                        5",
-            "prisonId=MDI,              3",
-            "status=DRAFT,              3",
-            "source=DPS,                3",
-            "source=NOMIS,              2",
-            "source=NOMIS&prisonId=MDI, 2",
-            "source=DPS&prisonId=MDI,   1",
-            "type=ASSAULT,              0",
-            "type=FIRE,                 1",
-            "type=FIRE&prisonId=LEI,    0",
-            "type=FIRE&prisonId=MDI,    1",
+            "'',                           5",
+            "prisonId=MDI,                 3",
+            "status=DRAFT,                 3",
+            "source=DPS,                   3",
+            "source=NOMIS,                 2",
+            "source=NOMIS&prisonId=MDI,    2",
+            "source=DPS&prisonId=MDI,      1",
+            "type=ASSAULT,                 0",
+            "type=FIRE,                    1",
+            "type=FIRE&prisonId=LEI,       0",
+            "type=FIRE&prisonId=MDI,       1",
+            "incidentDateFrom=2023-12-05,  1",
+            "incidentDateFrom=2023-12-04,  2",
+            "incidentDateFrom=2023-12-03,  3",
+            "incidentDateUntil=2023-12-03, 3",
+            "incidentDateUntil=2023-12-02, 2",
+            "incidentDateFrom=2023-12-02&incidentDateUntil=2023-12-02, 1",
           ],
         )
         fun `can filter reports`(params: String, count: Int) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncServiceTest.kt
@@ -185,7 +185,7 @@ class SyncServiceTest {
     return report.id == expectedId &&
       report.incidentNumber == sampleReport.incidentNumber &&
       report.incidentDateAndTime == sampleReport.incidentDateAndTime &&
-      report.getType() == sampleReport.getType() &&
+      report.type == sampleReport.type &&
       report.title == sampleReport.title &&
       report.description == sampleReport.description &&
       report.prisonId == sampleReport.prisonId &&


### PR DESCRIPTION
The initial endpoint returning reports did not permit filtering – it was intended to (slowly) serve _all_ reports for reconciliation page-by-page.

The endpoint becomes useful in a more general case now that filtering is possible by:
• prison
• information source
• report status
• incident type
• date range when the incident took place
• date range when the incident was reported