### PR TITLE
IR-242: Add deletion endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/ApplicationInsightsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/ApplicationInsightsConfiguration.kt
@@ -13,4 +13,6 @@ class ApplicationInsightsConfiguration {
   fun telemetryClient(): TelemetryClient = TelemetryClient()
 }
 
-fun TelemetryClient.trackEvent(name: String, properties: Map<String, String>) = this.trackEvent(name, properties, null)
+fun TelemetryClient.trackEvent(name: String, properties: Map<String, String>) {
+  trackEvent(name, properties, null)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
@@ -31,7 +31,7 @@ class Event(
   var title: String,
   var description: String,
 
-  @OneToMany(mappedBy = "event", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "event", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH], orphanRemoval = false)
   val reports: MutableList<Report> = mutableListOf(),
 
   var createdDate: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
@@ -31,7 +31,7 @@ class Event(
   var title: String,
   var description: String,
 
-  @OneToMany(mappedBy = "event", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH], orphanRemoval = false)
+  @OneToMany(mappedBy = "event", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   val reports: MutableList<Report> = mutableListOf(),
 
   var createdDate: LocalDateTime,
@@ -43,7 +43,10 @@ class Event(
   }
 
   fun addReport(report: Report): Report {
-    return reports.add(report).let { report }
+    return reports.add(report).let {
+      report.event = this
+      report
+    }
   }
 
   fun toDto() = EventDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -67,7 +67,7 @@ class Report(
   var reportedBy: String,
   var reportedDate: LocalDateTime,
 
-  @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], optional = false)
+  @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH], optional = false)
   val event: Event,
 
   @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -68,7 +68,7 @@ class Report(
   var reportedDate: LocalDateTime,
 
   @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH], optional = false)
-  val event: Event,
+  var event: Event,
 
   @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   val historyOfStatuses: MutableList<StatusHistory> = mutableListOf(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ApiExceptionHandler.kt
@@ -19,6 +19,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import java.util.UUID
 
 @RestControllerAdvice
 class ApiExceptionHandler {
@@ -255,6 +256,14 @@ class ApiExceptionHandler {
   }
 }
 
-class EventNotFoundException(id: String) : Exception("There is no event found for ID = $id")
-class ReportNotFoundException(id: String) : Exception("There is no incident report found for ID = $id")
-class ReportAlreadyExistsException(key: String) : Exception("Report already exists = $key")
+class EventNotFoundException(description: String) : Exception("There is no event found: $description") {
+  constructor(id: Long) : this(id.toString())
+}
+
+class ReportNotFoundException(description: String) : Exception("There is no report found: $description") {
+  constructor(id: UUID) : this(id.toString())
+}
+
+class ReportAlreadyExistsException(description: String) : Exception("Report already exists: $description") {
+  constructor(id: UUID) : this(id.toString())
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventBaseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventBaseResource.kt
@@ -14,7 +14,7 @@ abstract class EventBaseResource {
   protected fun eventPublishAndAudit(
     event: ReportDomainEventType,
     function: () -> Report,
-    informationSource: InformationSource = InformationSource.DPS,
+    informationSource: InformationSource,
   ) =
     function().also { report ->
       eventPublishAndAuditService.publishEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -340,11 +340,19 @@ class ReportResource(
     @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
     @PathVariable
     id: UUID,
+    @Schema(
+      description = "Whether orphaned events should also be deleted",
+      required = false,
+      defaultValue = "true",
+      example = "false",
+    )
+    @RequestParam(required = false)
+    deleteOrphanedEvents: Boolean = true,
   ): ReportDto {
     return eventPublishAndAudit(
       ReportDomainEventType.INCIDENT_REPORT_DELETED,
       {
-        reportService.deleteReportById(id)
+        reportService.deleteReportById(id, deleteOrphanedEvents)
           ?: throw ReportNotFoundException(id)
       },
       InformationSource.DPS,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -341,7 +341,13 @@ class ReportResource(
     @PathVariable
     id: UUID,
   ): ReportDto {
-    return reportService.deleteReportById(id)
-      ?: throw ReportNotFoundException(id)
+    return eventPublishAndAudit(
+      ReportDomainEventType.INCIDENT_REPORT_DELETED,
+      {
+        reportService.deleteReportById(id)
+          ?: throw ReportNotFoundException(id)
+      },
+      InformationSource.DPS,
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -204,11 +205,12 @@ class ReportResource(
     ],
   )
   fun getReport(
-    @Schema(description = "The incident report Id", example = "de91dfa7-821f-4552-a427-bf2f32eafeb0", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
     @PathVariable
     id: UUID,
   ): ReportDto {
-    return reportService.getReportById(id = id) ?: throw ReportNotFoundException(id.toString())
+    return reportService.getReportById(id = id)
+      ?: throw ReportNotFoundException(id)
   }
 
   @GetMapping("/incident-number/{incidentNumber}")
@@ -244,7 +246,8 @@ class ReportResource(
     @PathVariable
     incidentNumber: String,
   ): ReportDto {
-    return reportService.getReportByIncidentNumber(incidentNumber) ?: throw ReportNotFoundException(incidentNumber)
+    return reportService.getReportByIncidentNumber(incidentNumber)
+      ?: throw ReportNotFoundException(incidentNumber)
   }
 
   @PostMapping("", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -256,7 +259,7 @@ class ReportResource(
     responses = [
       ApiResponse(
         responseCode = "201",
-        description = "Returns created Incident Report",
+        description = "Returns created incident report",
       ),
       ApiResponse(
         responseCode = "400",
@@ -280,7 +283,7 @@ class ReportResource(
       ),
       ApiResponse(
         responseCode = "409",
-        description = "Incident Report already exists",
+        description = "Incident report already exists",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
     ],
@@ -297,5 +300,48 @@ class ReportResource(
       },
       InformationSource.DPS,
     )
+  }
+
+  // TODO: decide if a different role should be used!
+  @DeleteMapping("/{id}")
+  @PreAuthorize("hasRole('ROLE_MAINTAIN_INCIDENT_REPORTS') and hasAuthority('SCOPE_write')")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Deletes an incident report",
+    description = "Requires role MAINTAIN_INCIDENT_REPORTS and write scope",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns deleted incident report",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid Request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MAINTAIN_INCIDENT_REPORTS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun deleteReport(
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @PathVariable
+    id: UUID,
+  ): ReportDto {
+    return reportService.deleteReportById(id)
+      ?: throw ReportNotFoundException(id)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/AuditService.kt
@@ -70,4 +70,5 @@ data class AuditEvent(
 enum class AuditType {
   INCIDENT_REPORT_CREATED,
   INCIDENT_REPORT_AMENDED,
+  INCIDENT_REPORT_DELETED,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/AuditService.kt
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.config.AuthenticationFacade
+import uk.gov.justice.digital.hmpps.incidentreporting.config.trackEvent
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import java.time.Clock
@@ -41,18 +42,16 @@ class AuditService(
     )
     log.debug("Audit {} ", auditEvent)
 
-    val result =
-      auditSqsClient.sendMessage(
-        SendMessageRequest.builder()
-          .queueUrl(auditQueueUrl)
-          .messageBody(auditEvent.toJson())
-          .build(),
-      ).get()
+    val result = auditSqsClient.sendMessage(
+      SendMessageRequest.builder()
+        .queueUrl(auditQueueUrl)
+        .messageBody(auditEvent.toJson())
+        .build(),
+    ).get()
 
     telemetryClient.trackEvent(
       auditEvent.what,
       mapOf("messageId" to result.messageId(), "id" to id),
-      null,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/EventPublishAndAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/EventPublishAndAuditService.kt
@@ -15,9 +15,9 @@ class EventPublishAndAuditService(
 
   fun publishEvent(
     eventType: ReportDomainEventType,
-    reports: List<ReportDto>,
+    reports: Iterable<ReportDto>,
     auditData: Any? = null,
-    source: InformationSource = InformationSource.DPS,
+    source: InformationSource,
   ) {
     reports.forEach {
       publishEvent(
@@ -33,7 +33,7 @@ class EventPublishAndAuditService(
     eventType: ReportDomainEventType,
     report: ReportDto,
     auditData: Any? = null,
-    source: InformationSource = InformationSource.DPS,
+    source: InformationSource,
   ) {
     publishEvent(event = eventType, report = report, source = source)
 
@@ -67,7 +67,7 @@ class EventPublishAndAuditService(
     auditType: AuditType,
     id: String,
     auditData: Any,
-    source: InformationSource = InformationSource.DPS,
+    source: InformationSource,
   ) {
     auditService.sendMessage(
       auditType = auditType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -95,7 +95,7 @@ class ReportService(
       )
     } else if (createReportRequest.linkedEventId != null) {
       eventRepository.findOneByEventId(createReportRequest.linkedEventId)
-        ?: throw EventNotFoundException("Event with ID [${createReportRequest.linkedEventId}] not found")
+        ?: throw EventNotFoundException(createReportRequest.linkedEventId)
     } else {
       throw ValidationException("Either createNewEvent or linkedEventId must be provided")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.incidentreporting.config.AuthenticationFacade
+import uk.gov.justice.digital.hmpps.incidentreporting.config.trackEvent
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
@@ -105,7 +106,6 @@ class ReportService(
             "incidentNumber" to report.incidentNumber,
             "prisonId" to report.prisonId,
           ),
-          null,
         )
 
         eventIdToDelete?.let { eventId ->
@@ -149,7 +149,6 @@ class ReportService(
         "incidentNumber" to report.incidentNumber,
         "prisonId" to report.prisonId,
       ),
-      null,
     )
 
     return report

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -85,6 +85,12 @@ class ReportService(
     return reportRepository.findOneByIncidentNumber(incidentNumber)?.toDto()
   }
 
+  fun deleteReportById(id: UUID): ReportDto? {
+    return getReportById(id)?.apply {
+      reportRepository.deleteById(id)
+    }
+  }
+
   @Transactional
   fun createReport(createReportRequest: CreateReportRequest): ReportDto {
     val event = if (createReportRequest.createNewEvent) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -96,8 +96,22 @@ class ReportService(
       report.toDto().also {
         report.event.reports.removeIf { it.id == id }
         reportRepository.deleteById(id)
+
+        log.info("Deleted incident report number=${report.incidentNumber} ID=${report.id}")
+        telemetryClient.trackEvent(
+          "Deleted incident report",
+          mapOf(
+            "id" to report.id.toString(),
+            "incidentNumber" to report.incidentNumber,
+            "prisonId" to report.prisonId,
+          ),
+          null,
+        )
+
         eventIdToDelete?.let { eventId ->
           eventRepository.deleteById(eventId)
+
+          log.info("Deleted event ID=$eventId")
         }
       }
     }
@@ -127,11 +141,12 @@ class ReportService(
 
     val report = reportRepository.save(newReport).toDto()
 
-    log.info("Created incident report [${report.id}]")
+    log.info("Created incident report number=${report.incidentNumber} ID=${report.id}")
     telemetryClient.trackEvent(
       "Created incident report",
       mapOf(
         "id" to report.id.toString(),
+        "incidentNumber" to report.incidentNumber,
         "prisonId" to report.prisonId,
       ),
       null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -85,6 +85,7 @@ class ReportService(
     return reportRepository.findOneByIncidentNumber(incidentNumber)?.toDto()
   }
 
+  @Transactional
   fun deleteReportById(id: UUID): ReportDto? {
     return getReportById(id)?.apply {
       reportRepository.deleteById(id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SnsService.kt
@@ -99,6 +99,11 @@ enum class ReportDomainEventType(val value: String, val description: String, val
     "An incident report has been amended",
     AuditType.INCIDENT_REPORT_AMENDED,
   ),
+  INCIDENT_REPORT_DELETED(
+    "incident.report.deleted",
+    "An incident report has been deleted",
+    AuditType.INCIDENT_REPORT_DELETED,
+  ),
 }
 
 fun Instant.toOffsetDateFormat(): String =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncService.kt
@@ -52,7 +52,7 @@ class SyncService(
 
   private fun updateExistingReport(reportId: UUID, incidentReport: NomisReport): ReportDto {
     val reportToUpdate = reportRepository.findById(reportId)
-      .orElseThrow { ReportNotFoundException(reportId.toString()) }
+      .orElseThrow { ReportNotFoundException(reportId) }
     reportToUpdate.updateWith(incidentReport, clock)
     return reportToUpdate.toDto()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SyncService.kt
@@ -6,6 +6,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.incidentreporting.config.trackEvent
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.toNewEntity
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.NomisSyncRequest
@@ -45,7 +46,6 @@ class SyncService(
         "id" to report.id.toString(),
         "prisonId" to report.prisonId,
       ),
-      null,
     )
     return report
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -938,6 +938,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           .header("Content-Type", "application/json")
           .exchange()
           .expectStatus().isNotFound
+
+        assertThat(getNumberOfMessagesCurrentlyOnSubscriptionQueue()).isZero
       }
     }
 
@@ -961,6 +963,13 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """,
             false,
           )
+
+        getDomainEvents(1).let {
+          assertThat(it.map { message -> message.eventType to message.additionalInformation?.source })
+            .containsExactlyInAnyOrder(
+              "incident.report.deleted" to InformationSource.DPS,
+            )
+        }
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -486,6 +486,19 @@ class ReportResourceTest : SqsIntegrationTestBase() {
       }
     }
 
+    @DisplayName("validates requests")
+    @Nested
+    inner class Validation {
+      @Test
+      fun `cannot get a report by ID if it is not found`() {
+        webTestClient.get().uri("/incident-reports/11111111-2222-3333-4444-555555555555")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isNotFound
+      }
+    }
+
     @DisplayName("works")
     @Nested
     inner class HappyPath {
@@ -583,6 +596,19 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           .header("Content-Type", "application/json")
           .exchange()
           .expectStatus().isForbidden
+      }
+    }
+
+    @DisplayName("validates requests")
+    @Nested
+    inner class Validation {
+      @Test
+      fun `cannot get a report by incident number if it is not found`() {
+        webTestClient.get().uri("/incident-reports/incident-number/IR-11111111")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isNotFound
       }
     }
 


### PR DESCRIPTION
NOMIS sync needs to be able to delete reports, but it makes sense to promote this facility to be general purpose. Even if the incident reporting user-facing service does not allow deleting reports, the incident report _api_ ought to provide the mechanism anyway (being a CRUD REST api).

Now:
• reports can be deleted by primary key
• write scope is needed, but currently, only the regular `MAINTAIN_INCIDENT_REPORTS` role is required
• deletion is logged and a domain event is raised
• orphaned events are deleted by default