### PR TITLE
IR-247: Eager-load related entities from `Report`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
@@ -26,7 +26,7 @@ class HistoricalQuestion(
 
   val additionalInformation: String? = null,
 
-  @OneToMany(mappedBy = "historicalQuestion", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "historicalQuestion", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @OrderColumn(name = "sequence", nullable = false)
   private val responses: MutableList<HistoricalResponse> = mutableListOf(),
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/History.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/History.kt
@@ -30,7 +30,7 @@ class History(
   val changedAt: LocalDateTime,
   val changedBy: String,
 
-  @OneToMany(mappedBy = "history", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "history", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @OrderColumn(name = "sequence", nullable = false)
   val questions: MutableList<HistoricalQuestion> = mutableListOf(),
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
@@ -26,7 +26,7 @@ class Question(
 
   val additionalInformation: String? = null,
 
-  @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "question", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @OrderColumn(name = "sequence", nullable = false)
   private val responses: MutableList<Response> = mutableListOf(),
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -67,37 +67,37 @@ class Report(
   var reportedBy: String,
   var reportedAt: LocalDateTime,
 
-  @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH], optional = false)
+  @ManyToOne(fetch = FetchType.EAGER, cascade = [CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH], optional = false)
   var event: Event,
 
-  @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "report", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   val historyOfStatuses: MutableList<StatusHistory> = mutableListOf(),
 
   // TODO: what's this for?
   val assignedTo: String,
 
-  @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "report", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   val staffInvolved: MutableList<StaffInvolvement> = mutableListOf(),
 
-  @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "report", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   val prisonersInvolved: MutableList<PrisonerInvolvement> = mutableListOf(),
 
-  @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "report", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   val locations: MutableList<Location> = mutableListOf(),
 
-  @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "report", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   val evidence: MutableList<Evidence> = mutableListOf(),
 
-  @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "report", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   val correctionRequests: MutableList<CorrectionRequest> = mutableListOf(),
 
-  @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "report", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @OrderColumn(name = "sequence", nullable = false)
   private val questions: MutableList<Question> = mutableListOf(),
 
   var questionSetId: String? = null,
 
-  @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "report", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @OrderBy("changed_at ASC")
   val history: MutableList<History> = mutableListOf(),
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -71,6 +71,7 @@ class Report(
   var event: Event,
 
   @OneToMany(mappedBy = "report", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OrderBy("changed_at ASC")
   val historyOfStatuses: MutableList<StatusHistory> = mutableListOf(),
 
   // TODO: what's this for?

--- a/src/main/resources/db/migration/V1_1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1_1__initial_schema.sql
@@ -43,16 +43,27 @@ create table report
     modified_at            timestamp  default CURRENT_TIMESTAMP not null
 );
 
+create index report_incident_date_and_time_idx on report (incident_date_and_time);
+create index report_reported_at_idx on report (reported_at);
+create index report_created_at_idx on report (created_at);
+
+create index report_prison_id_idx on report (prison_id);
+create index report_source_idx on report (source);
+create index report_status_idx on report (status);
+create index report_type_idx on report (type);
+
 create table status_history
 (
-    id        serial
+    id         serial
         constraint status_history_pk primary key,
-    report_id uuid                                not null
+    report_id  uuid                                not null
         constraint status_history_report_fk references report (id) on delete cascade,
     status     varchar(60)                         not null,
     changed_at timestamp default CURRENT_TIMESTAMP not null,
     changed_by varchar(120)                        not null
 );
+
+create index status_history_changed_at_idx on status_history (changed_at);
 
 create table correction_request
 (
@@ -122,6 +133,8 @@ create table question
     additional_information text
 );
 
+create index question_sequence_at_idx on question (sequence);
+
 create table response
 (
     id                     serial
@@ -135,16 +148,20 @@ create table response
     recorded_by            varchar(120) default 'system'          not null
 );
 
+create index response_sequence_at_idx on response (sequence);
+
 create table history
 (
-    id                    serial
+    id         serial
         constraint history_pk primary key,
-    report_id             uuid         not null
+    report_id  uuid         not null
         constraint history_report_fk references report (id) on delete cascade,
     type       varchar(60)  not null,
     changed_at timestamp    not null,
     changed_by varchar(120) not null
 );
+
+create index history_changed_at_idx on history (changed_at);
 
 create table historical_question
 (
@@ -158,6 +175,8 @@ create table historical_question
     additional_information text
 );
 
+create index historical_question_sequence_at_idx on historical_question (sequence);
+
 create table historical_response
 (
     id                     serial
@@ -170,3 +189,5 @@ create table historical_response
     recorded_at            timestamp    default CURRENT_TIMESTAMP not null,
     recorded_by            varchar(120) default 'system'          not null
 );
+
+create index historical_response_sequence_at_idx on historical_response (sequence);


### PR DESCRIPTION
Selectively annotating some related entities to load eagerly, can slightly improve performance (though it remains poor).

This _appears_ to cut the number of SQL queries quite a bit for the report retrieving (both one and many).