### PR TITLE
IR-257: Return reports for SAR endpoint in stable order by incident date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SubjectAccessRequestService.kt
@@ -13,10 +13,13 @@ class SubjectAccessRequestService(
   override fun getPrisonContentFor(prn: String, fromDate: LocalDate?, toDate: LocalDate?): HmppsSubjectAccessRequestContent {
     val prisonerInvolvementList = prisonerInvolvementRepository.findAllByPrisonerNumber(prn)
     val content = prisonerInvolvementList
+      .asSequence()
       .map { it.getReport() }
       .distinctBy { it.id }
-      .filter { it.reportedAt.isAfter(fromDate?.atStartOfDay()) && it.reportedAt.isBefore(toDate?.atStartOfDay()) }
+      .filter { it.incidentDateAndTime.isAfter(fromDate?.atStartOfDay()) && it.incidentDateAndTime.isBefore(toDate?.atStartOfDay()) }
       .map { it.toDto() }
+      .sortedBy { it.incidentDateAndTime }
+      .toList()
     return HmppsSubjectAccessRequestContent(
       content = content,
     )


### PR DESCRIPTION
Previously, the order wasn’t stable and filtering was based on when the report was created (arguably a less interesting moment)