### PR TITLE
IR-68: Use same version of java for Veracode scanning as required by HMPPS plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ workflows:
           context:
             - hmpps-common-vars
       - hmpps/veracode_pipeline_scan:
+          jdk_tag: << pipeline.parameters.java-version >>
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - veracode-credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
     default: "21.0"
   postgres-version:
     type: string
-    default: "15"
+    default: "16"
   localstack-version:
     type: string
     default: "3"


### PR DESCRIPTION
Ref [hmpps-template-kotlin#209](https://github.com/ministryofjustice/hmpps-template-kotlin/pull/209)