### PR TITLE
IR-256: Listen to (but ignore) 'prisoner.merged' events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonOffenderEventListener.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.awspring.cloud.sqs.annotation.SqsListener
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class PrisonOffenderEventListener(
+  private val mapper: ObjectMapper,
+) {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+
+    const val PRISONER_MERGE_EVENT_TYPE = "prison-offender-events.prisoner.merged"
+  }
+
+  @SqsListener("incidentreporting", factory = "hmppsQueueContainerFactoryProxy")
+  @WithSpan(value = "hmpps-incident-reporting-prisoner-event-queue", kind = SpanKind.SERVER)
+  fun onPrisonOffenderEvent(requestJson: String) {
+    val (message, messageAttributes) = mapper.readValue(requestJson, HMPPSMessage::class.java)
+    val eventType = messageAttributes.eventType.Value
+    log.info("Received message $message, type $eventType")
+
+    when (eventType) {
+      PRISONER_MERGE_EVENT_TYPE -> {
+        val mergeEvent = mapper.readValue(message, HMPPSMergeDomainEvent::class.java)
+        // TODO: This is a no-op for now
+        log.debug("Ignoring '$PRISONER_MERGE_EVENT_TYPE' message")
+      }
+      else -> {
+        log.debug("Ignoring message with type $eventType")
+      }
+    }
+  }
+}
+
+data class HMPPSMergeDomainEvent(
+  val eventType: String? = null,
+  val additionalInformation: AdditionalInformationMerge,
+  val version: String,
+  val occurredAt: String,
+  val description: String,
+)
+
+data class AdditionalInformationMerge(
+  val nomsNumber: String,
+  val removedNomsNumber: String,
+)
+
+data class HMPPSEventType(val Value: String, val Type: String)
+data class HMPPSMessageAttributes(val eventType: HMPPSEventType)
+data class HMPPSMessage(
+  val Message: String,
+  val MessageAttributes: HMPPSMessageAttributes,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/SqsIntegrationTestBase.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.config.LocalStackContainer
 import uk.gov.justice.digital.hmpps.incidentreporting.config.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.incidentreporting.config.SYSTEM_USERNAME
 import uk.gov.justice.digital.hmpps.incidentreporting.service.HMPPSDomainEvent
+import uk.gov.justice.digital.hmpps.incidentreporting.service.HMPPSMessage
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsSqsProperties
@@ -119,10 +120,3 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
     }
   }
 }
-
-data class HMPPSEventType(val Value: String, val Type: String)
-data class HMPPSMessageAttributes(val eventType: HMPPSEventType)
-data class HMPPSMessage(
-  val Message: String,
-  val MessageAttributes: HMPPSMessageAttributes,
-)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,6 +27,14 @@ hmpps.sqs:
   queues:
     audit:
       queueName: ${random.uuid}
+    incidentreporting:
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
+      subscribeTopicId: domainevents
+      subscribeFilter: >-
+        {"eventType": [
+          "prison-offender-events.prisoner.merged"
+        ]}
     test:
       queueName: ${random.uuid}
       dlqName: ${random.uuid}


### PR DESCRIPTION
We are currently subscribed to these domain events but we didn't do anything with them.
This means messages accumulate in the queue and we're getting some alerts.

This should stop these alerts from happening.

PS: We will eventually have to introduce some logic to handle the merge of two prisoner numbers (e.g. updating prisoner involvement) but that's for another day.