### PR TITLE
IR-68: Create annotation for generation of UUID v7 values

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -6,13 +6,11 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderBy
 import jakarta.persistence.OrderColumn
-import org.hibernate.annotations.GenericGenerator
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.CorrectionReason
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.NO_DETAILS_GIVEN
@@ -27,7 +25,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisHistory
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisPrisonerInvolvements
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisQuestions
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.addNomisStaffInvolvements
-import uk.gov.justice.digital.hmpps.incidentreporting.jpa.id.UuidV7Generator
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.id.GeneratedUuidV7
 import java.time.Clock
 import java.time.LocalDateTime
 import java.util.UUID
@@ -36,8 +34,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.Report as ReportDto
 @Entity
 class Report(
   @Id
-  @GeneratedValue(generator = "UUID")
-  @GenericGenerator(name = "UUID", type = UuidV7Generator::class)
+  @GeneratedUuidV7
   @Column(name = "id", updatable = false, nullable = false)
   val id: UUID? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/id/UuidV7Generator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/id/UuidV7Generator.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.incidentreporting.jpa.id
 
 import com.fasterxml.uuid.Generators
 import com.fasterxml.uuid.NoArgGenerator
+import org.hibernate.annotations.IdGeneratorType
+import org.hibernate.annotations.ValueGenerationType
 import org.hibernate.engine.spi.SharedSessionContractImplementor
 import org.hibernate.generator.BeforeExecutionGenerator
 import org.hibernate.generator.EventType
-import org.hibernate.generator.EventTypeSets.INSERT_ONLY
+import org.hibernate.generator.EventTypeSets
 import java.util.EnumSet
 import java.util.UUID
 
@@ -15,7 +17,7 @@ class UuidV7Generator : BeforeExecutionGenerator {
   }
 
   override fun getEventTypes(): EnumSet<EventType> {
-    return INSERT_ONLY
+    return EventTypeSets.INSERT_ONLY
   }
 
   override fun generate(
@@ -28,3 +30,9 @@ class UuidV7Generator : BeforeExecutionGenerator {
     return uuidGenerator.generate()
   }
 }
+
+@IdGeneratorType(UuidV7Generator::class)
+@ValueGenerationType(generatedBy = UuidV7Generator::class)
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class GeneratedUuidV7


### PR DESCRIPTION
…because `org.hibernate.annotations.GenericGenerator` is deprecated as of hibernate 6.5 and the suggested alternative is to make a `@IdGeneratorType` annotation.