### PR TITLE
IR-269: Return incident report ID as an object from NOMIS sync resource

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/NomisSyncReportId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/NomisSyncReportId.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "Incident report ID")
+data class NomisSyncReportId(
+  @Schema(description = "The internal ID of this report", required = true)
+  val id: UUID,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -409,8 +409,8 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
           .bodyValue(jsonString(updatedSyncRequest))
           .exchange()
           .expectStatus().isCreated
-          .expectBody().consumeWith {
-            val reportId = objectMapper.readValue(it.responseBody, UUID::class.java)
+          .expectBody().jsonPath("id").value<String> {
+            val reportId = UUID.fromString(it)
             val report = reportRepository.findById(reportId).orElseThrow()
             val reportJson = objectMapper.writeValueAsString(report.toDto())
             JsonExpectationsHelper().assertJsonEqual(
@@ -667,8 +667,8 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
           .bodyValue(jsonString(newIncident))
           .exchange()
           .expectStatus().isCreated
-          .expectBody().consumeWith {
-            val reportId = objectMapper.readValue(it.responseBody, UUID::class.java)
+          .expectBody().jsonPath("id").value<String> {
+            val reportId = UUID.fromString(it)
             val report = reportRepository.findById(reportId).orElseThrow()
             val reportJson = objectMapper.writeValueAsString(report.toDto())
             JsonExpectationsHelper().assertJsonEqual(
@@ -1134,8 +1134,8 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
           .bodyValue(jsonString(upsertMigration))
           .exchange()
           .expectStatus().isOk
-          .expectBody().consumeWith {
-            val reportId = objectMapper.readValue(it.responseBody, UUID::class.java)
+          .expectBody().jsonPath("id").value<String> {
+            val reportId = UUID.fromString(it)
             val report = reportRepository.findById(reportId).orElseThrow()
             val reportJson = objectMapper.writeValueAsString(report.toDto())
             JsonExpectationsHelper().assertJsonEqual(


### PR DESCRIPTION
…instead of a string. I.e.:

Was:
```json
"019001e5-0233-75ce-afa3-1113d7dc7ec3"
```

Now:
```json
{"id": "019001e5-0233-75ce-afa3-1113d7dc7ec3"}
```