### PR TITLE
IR-273: Allow clients to choose between basic and with-details responses in single report endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/ReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/ReportRepository.kt
@@ -13,6 +13,8 @@ interface ReportRepository : JpaRepository<Report, UUID>, JpaSpecificationExecut
   @EntityGraph(value = "Report.eager", type = EntityGraph.EntityGraphType.FETCH)
   fun findOneEagerlyById(id: UUID): Report?
 
+  fun findByIncidentNumber(incidentNumber: String): Report?
+
   @EntityGraph(value = "Report.eager", type = EntityGraph.EntityGraphType.FETCH)
   fun findOneEagerlyByIncidentNumber(incidentNumber: String): Report?
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -178,7 +178,7 @@ class ReportResource(
       .toSimplePage()
   }
 
-  @GetMapping("/{id}")
+  @GetMapping("/{id}/with-details")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
   @Operation(
@@ -215,7 +215,7 @@ class ReportResource(
       ?: throw ReportNotFoundException(id)
   }
 
-  @GetMapping("/incident-number/{incidentNumber}")
+  @GetMapping("/incident-number/{incidentNumber}/with-details")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -178,6 +178,43 @@ class ReportResource(
       .toSimplePage()
   }
 
+  @GetMapping("/{id}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
+  @Operation(
+    summary = "Returns the incident report (with only basic information) for this ID",
+    description = "Requires role VIEW_INCIDENT_REPORTS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns an incident report",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the VIEW_INCIDENT_REPORTS role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getBasicReportById(
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @PathVariable
+    id: UUID,
+  ): ReportBasic {
+    return reportService.getBasicReportById(id = id)
+      ?: throw ReportNotFoundException(id)
+  }
+
   @GetMapping("/{id}/with-details")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
@@ -213,6 +250,43 @@ class ReportResource(
   ): ReportWithDetails {
     return reportService.getReportWithDetailsById(id = id)
       ?: throw ReportNotFoundException(id)
+  }
+
+  @GetMapping("/incident-number/{incidentNumber}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
+  @Operation(
+    summary = "Returns the incident report (with only basic information) for this incident number",
+    description = "Requires role VIEW_INCIDENT_REPORTS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns an incident report",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the VIEW_INCIDENT_REPORTS role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getBasicReportByIncidentNumber(
+    @Schema(description = "The incident report number", example = "2342341242", required = true)
+    @PathVariable
+    incidentNumber: String,
+  ): ReportBasic {
+    return reportService.getBasicReportByIncidentNumber(incidentNumber)
+      ?: throw ReportNotFoundException(incidentNumber)
   }
 
   @GetMapping("/incident-number/{incidentNumber}/with-details")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.resource.EventNotFoundExce
 import java.time.Clock
 import java.time.LocalDate
 import java.util.UUID
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 @Transactional(readOnly = true)
@@ -75,6 +76,16 @@ class ReportService(
     )
     return reportRepository.findAll(specification, pageable)
       .map { it.toDtoBasic() }
+  }
+
+  fun getBasicReportById(id: UUID): ReportBasic? {
+    return reportRepository.findById(id).getOrNull()
+      ?.toDtoBasic()
+  }
+
+  fun getBasicReportByIncidentNumber(incidentNumber: String): ReportBasic? {
+    return reportRepository.findByIncidentNumber(incidentNumber)
+      ?.toDtoBasic()
   }
 
   fun getReportWithDetailsById(id: UUID): ReportWithDetails? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/JwtAuthHelper.kt
@@ -28,8 +28,8 @@ class JwtAuthHelper {
 
   fun setAuthorisation(
     user: String = SYSTEM_USERNAME,
-    roles: List<String> = listOf(),
-    scopes: List<String> = listOf(),
+    roles: List<String> = emptyList(),
+    scopes: List<String> = emptyList(),
   ): (HttpHeaders) -> Unit {
     val token = createJwt(
       subject = user,
@@ -42,8 +42,8 @@ class JwtAuthHelper {
 
   internal fun createJwt(
     subject: String?,
-    scope: List<String>? = listOf(),
-    roles: List<String>? = listOf(),
+    scope: List<String>? = emptyList(),
+    roles: List<String>? = emptyList(),
     expiryTime: Duration = Duration.ofHours(1),
     jwtId: String = UUID.randomUUID().toString(),
   ): String =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/EntityToDtoMappingEdgeCaseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/EntityToDtoMappingEdgeCaseTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.incidentreporting.dto
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,6 +20,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepos
  * Largely, these mappings are field-by-field copies.
  * NB: most conversions are already covered by resource and service tests.
  */
+@DisplayName("Mapping JPA entities to DTOs")
 class EntityToDtoMappingEdgeCaseTest : SqsIntegrationTestBase() {
   @Autowired
   lateinit var eventRepository: EventRepository
@@ -73,6 +75,7 @@ class EntityToDtoMappingEdgeCaseTest : SqsIntegrationTestBase() {
     assertThat(reportFromDps.toDtoWithDetails().createdInNomis).isFalse()
   }
 
+  @DisplayName("serialisation to JSON")
   @Nested
   inner class Serialisation {
     private lateinit var report: Report

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/EntityToDtoMappingEdgeCaseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/EntityToDtoMappingEdgeCaseTest.kt
@@ -99,14 +99,14 @@ class EntityToDtoMappingEdgeCaseTest : SqsIntegrationTestBase() {
     @Test
     fun `can serialise basic report`() {
       val expectedJson = getResource("/entity-mapping/sample-report-basic.json")
-      val json = objectMapper.writeValueAsString(report.toDtoBasic())
+      val json = report.toDtoBasic().toJson()
       JsonExpectationsHelper().assertJsonEqual(expectedJson, json, false)
     }
 
     @Test
     fun `can serialise report with all related details`() {
       val expectedJson = getResource("/entity-mapping/sample-report-with-details.json")
-      val json = objectMapper.writeValueAsString(report.toDtoWithDetails())
+      val json = report.toDtoWithDetails().toJson()
       JsonExpectationsHelper().assertJsonEqual(expectedJson, json, false)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.integration.IntegrationTes
  * At present, these are mostly field-by-field copies with some fields renamed.
  * NB: most conversions are already covered by resource and service tests.
  */
+@DisplayName("Mapping NOMIS DTOs to JPA entities")
 class NomisDtoToJpaMappingEdgeCaseTest {
   private val minimalReportDto = NomisReport(
     incidentId = 112414323,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/SqsIntegrationTestBase.kt
@@ -107,7 +107,7 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
     scopes: List<String> = listOf(),
   ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation(user, roles, scopes)
 
-  protected fun jsonString(any: Any) = objectMapper.writeValueAsString(any) as String
+  protected fun Any.toJson(): String = objectMapper.writeValueAsString(this)
 
   companion object {
     private val localStackContainer = LocalStackContainer.instance

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterB
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByType
 import java.util.UUID
 
+@DisplayName("Report repository")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.incidentreporting.integration.SqsIntegrationTestBase
 
+@DisplayName("Constants resource")
 class ConstantsResourceTest : SqsIntegrationTestBase() {
   @ParameterizedTest(name = "cannot access {0} constants without authorisation")
   @ValueSource(strings = ["prisoner-outcomes", "prisoner-roles", "staff-roles", "statuses", "types"])

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -309,7 +309,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri("/sync/upsert")
           .headers(setAuthorisation(roles = listOf()))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(syncRequest))
+          .bodyValue(syncRequest.toJson())
           .exchange()
           .expectStatus().isForbidden
       }
@@ -319,7 +319,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri("/sync/upsert")
           .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(syncRequest))
+          .bodyValue(syncRequest.toJson())
           .exchange()
           .expectStatus().isForbidden
       }
@@ -329,7 +329,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri("/sync/upsert")
           .headers(setAuthorisation(roles = listOf("ROLE_BANANAS"), scopes = listOf("read")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(syncRequest))
+          .bodyValue(syncRequest.toJson())
           .exchange()
           .expectStatus().isForbidden
       }
@@ -370,7 +370,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri("/sync/upsert")
           .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(initialSyncRequest))
+          .bodyValue(initialSyncRequest.toJson())
           .exchange()
           .expectStatus().isCreated
 
@@ -384,7 +384,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri("/sync/upsert")
           .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(initialSyncRequestRetry))
+          .bodyValue(initialSyncRequestRetry.toJson())
           .exchange()
           .expectStatus().isEqualTo(HttpStatus.CONFLICT)
           .expectBody().jsonPath("developerMessage").value<String> {
@@ -408,13 +408,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri("/sync/upsert")
           .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(updatedSyncRequest))
+          .bodyValue(updatedSyncRequest.toJson())
           .exchange()
           .expectStatus().isCreated
           .expectBody().jsonPath("id").value<String> {
             val reportId = UUID.fromString(it)
             val report = reportRepository.findOneEagerlyById(reportId)!!.toDtoWithDetails()
-            val reportJson = objectMapper.writeValueAsString(report)
+            val reportJson = report.toJson()
             JsonExpectationsHelper().assertJsonEqual(
               // language=json
               """
@@ -666,13 +666,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri("/sync/upsert")
           .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(newIncident))
+          .bodyValue(newIncident.toJson())
           .exchange()
           .expectStatus().isCreated
           .expectBody().jsonPath("id").value<String> {
             val reportId = UUID.fromString(it)
             val report = reportRepository.findOneEagerlyById(reportId)!!.toDtoWithDetails()
-            val reportJson = objectMapper.writeValueAsString(report)
+            val reportJson = report.toJson()
             JsonExpectationsHelper().assertJsonEqual(
               // language=json
               """
@@ -1133,13 +1133,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri("/sync/upsert")
           .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(upsertMigration))
+          .bodyValue(upsertMigration.toJson())
           .exchange()
           .expectStatus().isOk
           .expectBody().jsonPath("id").value<String> {
             val reportId = UUID.fromString(it)
             val report = reportRepository.findOneEagerlyById(reportId)!!.toDtoWithDetails()
-            val reportJson = objectMapper.writeValueAsString(report)
+            val reportJson = report.toJson()
             JsonExpectationsHelper().assertJsonEqual(
               // language=json
               """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
@@ -295,45 +296,12 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
     )
 
     @DisplayName("is secured")
-    @Nested
-    inner class Security {
-      @Test
-      fun `access forbidden when no authority`() {
-        webTestClient.post().uri("/sync/upsert")
-          .exchange()
-          .expectStatus().isUnauthorized
-      }
-
-      @Test
-      fun `access forbidden when no role`() {
-        webTestClient.post().uri("/sync/upsert")
-          .headers(setAuthorisation(roles = listOf()))
-          .header("Content-Type", "application/json")
-          .bodyValue(syncRequest.toJson())
-          .exchange()
-          .expectStatus().isForbidden
-      }
-
-      @Test
-      fun `access forbidden with wrong role`() {
-        webTestClient.post().uri("/sync/upsert")
-          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
-          .header("Content-Type", "application/json")
-          .bodyValue(syncRequest.toJson())
-          .exchange()
-          .expectStatus().isForbidden
-      }
-
-      @Test
-      fun `access forbidden with right role, wrong scope`() {
-        webTestClient.post().uri("/sync/upsert")
-          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS"), scopes = listOf("read")))
-          .header("Content-Type", "application/json")
-          .bodyValue(syncRequest.toJson())
-          .exchange()
-          .expectStatus().isForbidden
-      }
-    }
+    @TestFactory
+    fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+      webTestClient.post().uri("/sync/upsert").bodyValue(syncRequest.toJson()),
+      "MIGRATE_INCIDENT_REPORTS",
+      "write",
+    )
 
     @DisplayName("validates requests")
     @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -40,6 +40,7 @@ import java.util.UUID
 
 private const val INCIDENT_NUMBER: Long = 112414323
 
+@DisplayName("NOMIS sync resource")
 @Transactional
 class NomisSyncResourceTest : SqsIntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
@@ -59,33 +60,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     private val url = "/incident-reports"
 
     @DisplayName("is secured")
-    @Nested
-    inner class Security {
-      @Test
-      fun `access forbidden when no authority`() {
-        webTestClient.get().uri(url)
-          .exchange()
-          .expectStatus().isUnauthorized
-      }
-
-      @Test
-      fun `access forbidden when no role`() {
-        webTestClient.get().uri(url)
-          .headers(setAuthorisation(roles = listOf()))
-          .header("Content-Type", "application/json")
-          .exchange()
-          .expectStatus().isForbidden
-      }
-
-      @Test
-      fun `access forbidden with wrong role`() {
-        webTestClient.get().uri(url)
-          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
-          .header("Content-Type", "application/json")
-          .exchange()
-          .expectStatus().isForbidden
-      }
-    }
+    @TestFactory
+    fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+      webTestClient.get().uri(url),
+      "VIEW_INCIDENT_REPORTS",
+    )
 
     @DisplayName("validates requests")
     @Nested
@@ -416,33 +395,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
 
     @DisplayName("is secured")
-    @Nested
-    inner class Security {
-      @Test
-      fun `access forbidden when no authority`() {
-        webTestClient.get().uri(url)
-          .exchange()
-          .expectStatus().isUnauthorized
-      }
-
-      @Test
-      fun `access forbidden when no role`() {
-        webTestClient.get().uri(url)
-          .headers(setAuthorisation(roles = listOf()))
-          .header("Content-Type", "application/json")
-          .exchange()
-          .expectStatus().isForbidden
-      }
-
-      @Test
-      fun `access forbidden with wrong role`() {
-        webTestClient.get().uri(url)
-          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
-          .header("Content-Type", "application/json")
-          .exchange()
-          .expectStatus().isForbidden
-      }
-    }
+    @TestFactory
+    fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+      webTestClient.get().uri(url),
+      "VIEW_INCIDENT_REPORTS",
+    )
 
     @DisplayName("validates requests")
     @Nested
@@ -529,33 +486,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
 
     @DisplayName("is secured")
-    @Nested
-    inner class Security {
-      @Test
-      fun `access forbidden when no authority`() {
-        webTestClient.get().uri(url)
-          .exchange()
-          .expectStatus().isUnauthorized
-      }
-
-      @Test
-      fun `access forbidden when no role`() {
-        webTestClient.get().uri(url)
-          .headers(setAuthorisation(roles = listOf()))
-          .header("Content-Type", "application/json")
-          .exchange()
-          .expectStatus().isForbidden
-      }
-
-      @Test
-      fun `access forbidden with wrong role`() {
-        webTestClient.get().uri(url)
-          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
-          .header("Content-Type", "application/json")
-          .exchange()
-          .expectStatus().isForbidden
-      }
-    }
+    @TestFactory
+    fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+      webTestClient.get().uri(url),
+      "VIEW_INCIDENT_REPORTS",
+    )
 
     @DisplayName("validates requests")
     @Nested
@@ -648,46 +583,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     )
 
     @DisplayName("is secured")
-    @Nested
-    inner class Security {
-      @Test
-      fun `access forbidden when no authority`() {
-        webTestClient.post().uri(url)
-          .bodyValue(createReportRequest.toJson())
-          .exchange()
-          .expectStatus().isUnauthorized
-      }
-
-      @Test
-      fun `access forbidden when no role`() {
-        webTestClient.post().uri(url)
-          .headers(setAuthorisation(roles = listOf()))
-          .header("Content-Type", "application/json")
-          .bodyValue(createReportRequest.toJson())
-          .exchange()
-          .expectStatus().isForbidden
-      }
-
-      @Test
-      fun `access forbidden with wrong role`() {
-        webTestClient.post().uri(url)
-          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
-          .header("Content-Type", "application/json")
-          .bodyValue(createReportRequest.toJson())
-          .exchange()
-          .expectStatus().isForbidden
-      }
-
-      @Test
-      fun `access forbidden with right role, wrong scope`() {
-        webTestClient.post().uri(url)
-          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("read")))
-          .header("Content-Type", "application/json")
-          .bodyValue(createReportRequest.toJson())
-          .exchange()
-          .expectStatus().isForbidden
-      }
-    }
+    @TestFactory
+    fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+      webTestClient.post().uri(url).bodyValue(createReportRequest.toJson()),
+      "VIEW_INCIDENT_REPORTS",
+      "write",
+    )
 
     @DisplayName("validates requests")
     @Nested
@@ -873,33 +774,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
 
     @DisplayName("is secured")
-    @Nested
-    inner class Security {
-      @Test
-      fun `access forbidden when no authority`() {
-        webTestClient.delete().uri(url)
-          .exchange()
-          .expectStatus().isUnauthorized
-      }
-
-      @Test
-      fun `access forbidden when no role`() {
-        webTestClient.delete().uri(url)
-          .headers(setAuthorisation(roles = listOf()))
-          .header("Content-Type", "application/json")
-          .exchange()
-          .expectStatus().isForbidden
-      }
-
-      @Test
-      fun `access forbidden with wrong role`() {
-        webTestClient.delete().uri(url)
-          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
-          .header("Content-Type", "application/json")
-          .exchange()
-          .expectStatus().isForbidden
-      }
-    }
+    @TestFactory
+    fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+      webTestClient.delete().uri(url),
+      "MAINTAIN_INCIDENT_REPORTS",
+      "write",
+    )
 
     @DisplayName("validates requests")
     @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventReposi
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
 import java.time.Clock
 
+@DisplayName("Report resource")
 class ReportResourceTest : SqsIntegrationTestBase() {
 
   @TestConfiguration

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -384,14 +384,14 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
   }
 
-  @DisplayName("GET /incident-reports/{id}")
+  @DisplayName("GET /incident-reports/{id}/with-details")
   @Nested
   inner class GetReportById {
     private lateinit var url: String
 
     @BeforeEach
     fun setUp() {
-      url = "/incident-reports/${existingReport.id}"
+      url = "/incident-reports/${existingReport.id}/with-details"
     }
 
     @DisplayName("is secured")
@@ -406,7 +406,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     inner class Validation {
       @Test
       fun `cannot get a report by ID if it is not found`() {
-        webTestClient.get().uri("/incident-reports/11111111-2222-3333-4444-555555555555")
+        webTestClient.get().uri("/incident-reports/11111111-2222-3333-4444-555555555555/with-details")
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
           .header("Content-Type", "application/json")
           .exchange()
@@ -475,14 +475,14 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
   }
 
-  @DisplayName("GET /incident-reports/incident-number/{incident-number}")
+  @DisplayName("GET /incident-reports/incident-number/{incident-number}/with-details")
   @Nested
   inner class GetReportByIncidentNumber {
     private lateinit var url: String
 
     @BeforeEach
     fun setUp() {
-      url = "/incident-reports/incident-number/${existingReport.incidentNumber}"
+      url = "/incident-reports/incident-number/${existingReport.incidentNumber}/with-details"
     }
 
     @DisplayName("is secured")
@@ -497,7 +497,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     inner class Validation {
       @Test
       fun `cannot get a report by incident number if it is not found`() {
-        webTestClient.get().uri("/incident-reports/incident-number/IR-11111111")
+        webTestClient.get().uri("/incident-reports/incident-number/IR-11111111/with-details")
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
           .header("Content-Type", "application/json")
           .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -653,7 +653,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
       @Test
       fun `access forbidden when no authority`() {
         webTestClient.post().uri(url)
-          .bodyValue(jsonString(createReportRequest))
+          .bodyValue(createReportRequest.toJson())
           .exchange()
           .expectStatus().isUnauthorized
       }
@@ -663,7 +663,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri(url)
           .headers(setAuthorisation(roles = listOf()))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(createReportRequest))
+          .bodyValue(createReportRequest.toJson())
           .exchange()
           .expectStatus().isForbidden
       }
@@ -673,7 +673,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(createReportRequest))
+          .bodyValue(createReportRequest.toJson())
           .exchange()
           .expectStatus().isForbidden
       }
@@ -683,7 +683,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("read")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(createReportRequest))
+          .bodyValue(createReportRequest.toJson())
           .exchange()
           .expectStatus().isForbidden
       }
@@ -707,7 +707,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(createReportRequest.copy(createNewEvent = false)))
+          .bodyValue(createReportRequest.copy(createNewEvent = false).toJson())
           .exchange()
           .expectStatus().isBadRequest
           .expectBody().jsonPath("developerMessage").value<String> {
@@ -720,13 +720,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(
-            jsonString(
-              createReportRequest.copy(
-                type = Type.OLD_ASSAULT,
-              ),
-            ),
-          )
+          .bodyValue(createReportRequest.copy(type = Type.OLD_ASSAULT).toJson())
           .exchange()
           .expectStatus().isBadRequest
           .expectBody().jsonPath("developerMessage").value<String> {
@@ -743,7 +737,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(createReportRequest))
+          .bodyValue(createReportRequest.toJson())
           .exchange()
           .expectStatus().isCreated
           .expectBody().json(
@@ -804,7 +798,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(createReportRequest.copy(createNewEvent = false, linkedEventId = existingReport.event.eventId)))
+          .bodyValue(
+            createReportRequest.copy(
+              createNewEvent = false,
+              linkedEventId = existingReport.event.eventId,
+            ).toJson(),
+          )
           .exchange()
           .expectStatus().isCreated
           .expectBody().json(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -384,9 +384,76 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
   }
 
+  @DisplayName("GET /incident-reports/{id}")
+  @Nested
+  inner class GetBasicReportById {
+    private lateinit var url: String
+
+    @BeforeEach
+    fun setUp() {
+      url = "/incident-reports/${existingReport.id}"
+    }
+
+    @DisplayName("is secured")
+    @TestFactory
+    fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+      webTestClient.get().uri(url),
+      "VIEW_INCIDENT_REPORTS",
+    )
+
+    @DisplayName("validates requests")
+    @Nested
+    inner class Validation {
+      @Test
+      fun `cannot get a report by ID if it is not found`() {
+        webTestClient.get().uri("/incident-reports/11111111-2222-3333-4444-555555555555")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isNotFound
+      }
+    }
+
+    @DisplayName("works")
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `can get a report by ID`() {
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """ 
+            {
+              "id": "${existingReport.id}",
+              "incidentNumber": "IR-0000000001124143",
+              "type": "FINDS",
+              "incidentDateAndTime": "2023-12-05T11:34:56",
+              "prisonId": "MDI",
+              "title": "Incident Report IR-0000000001124143",
+              "description": "A new incident created in the new service of type Finds",
+              "reportedBy": "USER1",
+              "reportedAt": "2023-12-05T12:34:56",
+              "status": "DRAFT",
+              "assignedTo": "USER1",
+              "createdAt": "2023-12-05T12:34:56",
+              "modifiedAt": "2023-12-05T12:34:56",
+              "modifiedBy": "USER1",
+              "createdInNomis": false
+            }
+            """,
+            true,
+          )
+      }
+    }
+  }
+
   @DisplayName("GET /incident-reports/{id}/with-details")
   @Nested
-  inner class GetReportById {
+  inner class GetReportWithDetailsById {
     private lateinit var url: String
 
     @BeforeEach
@@ -475,9 +542,76 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
   }
 
+  @DisplayName("GET /incident-reports/incident-number/{incident-number}")
+  @Nested
+  inner class GetBasicReportByIncidentNumber {
+    private lateinit var url: String
+
+    @BeforeEach
+    fun setUp() {
+      url = "/incident-reports/incident-number/${existingReport.incidentNumber}"
+    }
+
+    @DisplayName("is secured")
+    @TestFactory
+    fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+      webTestClient.get().uri(url),
+      "VIEW_INCIDENT_REPORTS",
+    )
+
+    @DisplayName("validates requests")
+    @Nested
+    inner class Validation {
+      @Test
+      fun `cannot get a report by incident number if it is not found`() {
+        webTestClient.get().uri("/incident-reports/incident-number/IR-11111111")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isNotFound
+      }
+    }
+
+    @DisplayName("works")
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `can get a report by incident number`() {
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """ 
+            {
+              "id": "${existingReport.id}",
+              "incidentNumber": "IR-0000000001124143",
+              "type": "FINDS",
+              "incidentDateAndTime": "2023-12-05T11:34:56",
+              "prisonId": "MDI",
+              "title": "Incident Report IR-0000000001124143",
+              "description": "A new incident created in the new service of type Finds",
+              "reportedBy": "USER1",
+              "reportedAt": "2023-12-05T12:34:56",
+              "status": "DRAFT",
+              "assignedTo": "USER1",
+              "createdAt": "2023-12-05T12:34:56",
+              "modifiedAt": "2023-12-05T12:34:56",
+              "modifiedBy": "USER1",
+              "createdInNomis": false
+            }
+            """,
+            true,
+          )
+      }
+    }
+  }
+
   @DisplayName("GET /incident-reports/incident-number/{incident-number}/with-details")
   @Nested
-  inner class GetReportByIncidentNumber {
+  inner class GetReportWithDetailsByIncidentNumber {
     private lateinit var url: String
 
     @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
@@ -5,6 +5,7 @@ import jakarta.validation.ValidationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.hibernate.exception.ConstraintViolationException
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -45,6 +46,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.resource.ReportNotFoundExc
 import java.sql.SQLException
 import java.util.UUID
 
+@DisplayName("NOMIS sync service")
 class NomisSyncServiceTest {
   private val reportRepository: ReportRepository = mock()
   private val telemetryClient: TelemetryClient = mock()


### PR DESCRIPTION
It would have taken less code to have responses switch based on a request parameter, but the OpenAPI schema is probably cleaner without using an `oneOf` return type.