### PR TITLE
IR-281 & IR-282: Allow changing a report’s status or type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/ChangeStatusRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/ChangeStatusRequest.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
+
+@Schema(description = "Changes an incident report’s status")
+data class ChangeStatusRequest(
+  @Schema(description = "The new status", required = true, example = "CLOSED")
+  val newStatus: Status,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/ChangeTypeRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/ChangeTypeRequest.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.ValidationException
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
+
+@Schema(description = "Changes an incident report’s type")
+data class ChangeTypeRequest(
+  @Schema(description = "The new type", required = true, example = "DAMAGE")
+  val newType: Type,
+) {
+  fun validate() {
+    if (!newType.active) {
+      throw ValidationException("Inactive incident type $newType")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/utils/MaybeChanged.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/utils/MaybeChanged.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto.utils
+
+/**
+ * Represents a value that might have been changed,
+ * allowing a block to be called only if it had been changed.
+ */
+sealed interface MaybeChanged<T> {
+  val value: T
+
+  fun alsoIfChanged(block: (T) -> Unit): MaybeChanged<T>
+
+  data class Unchanged<T>(override val value: T) : MaybeChanged<T> {
+    override fun alsoIfChanged(block: (T) -> Unit): Unchanged<T> {
+      return this
+    }
+  }
+
+  data class Changed<T>(override val value: T) : MaybeChanged<T> {
+    override fun alsoIfChanged(block: (T) -> Unit): Changed<T> {
+      block(value)
+      return this
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -156,6 +156,12 @@ class Report(
     return this
   }
 
+  fun changeStatus(newStatus: Status, changedAt: LocalDateTime, changedBy: String): Report {
+    status = newStatus
+    addStatusHistory(newStatus, changedAt, changedBy)
+    return this
+  }
+
   fun addStatusHistory(status: Status, changedAt: LocalDateTime, changedBy: String): StatusHistory {
     return StatusHistory(
       report = this,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ApiExceptionHandler.kt
@@ -120,7 +120,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(WebClientResponseException.NotFound::class)
-  fun handleSpringNotFound(e: WebClientResponseException.NotFound): ResponseEntity<ErrorResponse?>? {
+  fun handleSpringNotFound(e: WebClientResponseException.NotFound): ResponseEntity<ErrorResponse> {
     log.debug("Not found exception caught: {}", e.message)
     return ResponseEntity
       .status(HttpStatus.NOT_FOUND)
@@ -134,7 +134,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(NoResourceFoundException::class)
-  fun handleNoResourceFoundException(e: NoResourceFoundException): ResponseEntity<ErrorResponse?>? {
+  fun handleNoResourceFoundException(e: NoResourceFoundException): ResponseEntity<ErrorResponse> {
     log.debug("No resource found exception caught: {}", e.message)
     return ResponseEntity
       .status(HttpStatus.NOT_FOUND)
@@ -148,7 +148,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(ResponseStatusException::class)
-  fun handleResponseStatusException(e: ResponseStatusException): ResponseEntity<ErrorResponse?>? {
+  fun handleResponseStatusException(e: ResponseStatusException): ResponseEntity<ErrorResponse> {
     log.debug("Response status exception caught: {}", e.message)
     val reason = e.reason ?: "Unknown error"
     return ResponseEntity
@@ -163,7 +163,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(java.lang.Exception::class)
-  fun handleException(e: java.lang.Exception): ResponseEntity<ErrorResponse?>? {
+  fun handleException(e: java.lang.Exception): ResponseEntity<ErrorResponse> {
     log.error("Unexpected exception", e)
     return ResponseEntity
       .status(INTERNAL_SERVER_ERROR)
@@ -177,7 +177,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(MethodArgumentNotValidException::class)
-  fun handleInvalidMethodArgumentException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse>? {
+  fun handleInvalidMethodArgumentException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
     val message = e.allErrors.joinToString(", ") {
       val field = if (it is FieldError) {
         "${it.objectName}.${it.field}"
@@ -200,7 +200,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(PropertyReferenceException::class)
-  fun handlePropertyReferenceException(e: PropertyReferenceException): ResponseEntity<ErrorResponse>? {
+  fun handlePropertyReferenceException(e: PropertyReferenceException): ResponseEntity<ErrorResponse> {
     log.debug("PropertyReferenceException caught: {}", e.message)
 
     return ResponseEntity
@@ -216,7 +216,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(EventNotFoundException::class)
-  fun handleEventNotFound(e: EventNotFoundException): ResponseEntity<ErrorResponse?>? {
+  fun handleEventNotFound(e: EventNotFoundException): ResponseEntity<ErrorResponse> {
     log.debug("Event not found exception caught: {}", e.message)
     return ResponseEntity
       .status(HttpStatus.NOT_FOUND)
@@ -231,7 +231,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(ReportNotFoundException::class)
-  fun handleReportNotFound(e: ReportNotFoundException): ResponseEntity<ErrorResponse?>? {
+  fun handleReportNotFound(e: ReportNotFoundException): ResponseEntity<ErrorResponse> {
     log.debug("Report not found exception caught: {}", e.message)
     return ResponseEntity
       .status(HttpStatus.NOT_FOUND)
@@ -246,7 +246,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(ReportAlreadyExistsException::class)
-  fun handleReportAlreadyExists(e: ReportAlreadyExistsException): ResponseEntity<ErrorResponse?>? {
+  fun handleReportAlreadyExists(e: ReportAlreadyExistsException): ResponseEntity<ErrorResponse> {
     log.debug("Report already exists exception caught: {}", e.message)
     return ResponseEntity
       .status(HttpStatus.CONFLICT)
@@ -261,7 +261,7 @@ class ApiExceptionHandler {
   }
 
   @ExceptionHandler(ObjectAtIndexNotFoundException::class)
-  fun handleObjectAtIndexNotFound(e: ObjectAtIndexNotFoundException): ResponseEntity<ErrorResponse?>? {
+  fun handleObjectAtIndexNotFound(e: ObjectAtIndexNotFoundException): ResponseEntity<ErrorResponse> {
     log.debug(e.message)
     return ResponseEntity
       .status(HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResource.kt
@@ -48,7 +48,7 @@ class NomisSyncResource(
       ),
       ApiResponse(
         responseCode = "400",
-        description = "Invalid Request",
+        description = "Invalid request",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.ReportBasic
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.ReportWithDetails
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.ChangeStatusRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.CreateReportRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.UpdateReportRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.SimplePage
@@ -424,6 +425,61 @@ class ReportResource(
     }
   }
 
+  @PatchMapping("/{id}/status")
+  @PreAuthorize("hasRole('ROLE_MAINTAIN_INCIDENT_REPORTS') and hasAuthority('SCOPE_write')")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Changes the status of an existing incident report",
+    description = "Requires role MAINTAIN_INCIDENT_REPORTS and write scope",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns updated incident report",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MAINTAIN_INCIDENT_REPORTS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun changeReportStatus(
+    @Schema(description = "The internal ID of the report to update", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @PathVariable
+    id: UUID,
+    @RequestBody
+    @Valid
+    changeStatusRequest: ChangeStatusRequest,
+  ): ReportWithDetails {
+    val (report, changed) = reportService.changeReportStatus(id, changeStatusRequest)
+      ?: throw ReportNotFoundException(id)
+    return report.also {
+      if (changed) {
+        eventPublishAndAudit(
+          ReportDomainEventType.INCIDENT_REPORT_AMENDED,
+          InformationSource.DPS,
+        ) {
+          it
+        }
+      }
+    }
+  }
+
   // TODO: decide if a different role should be used!
   @DeleteMapping("/{id}")
   @PreAuthorize("hasRole('ROLE_MAINTAIN_INCIDENT_REPORTS') and hasAuthority('SCOPE_write')")
@@ -438,7 +494,7 @@ class ReportResource(
       ),
       ApiResponse(
         responseCode = "400",
-        description = "Invalid Request",
+        description = "Invalid request",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -467,18 +467,17 @@ class ReportResource(
     @Valid
     changeStatusRequest: ChangeStatusRequest,
   ): ReportWithDetails {
-    val (report, changed) = reportService.changeReportStatus(id, changeStatusRequest)
+    val maybeChangedReport = reportService.changeReportStatus(id, changeStatusRequest)
       ?: throw ReportNotFoundException(id)
-    return report.also {
-      if (changed) {
-        eventPublishAndAudit(
-          ReportDomainEventType.INCIDENT_REPORT_AMENDED,
-          InformationSource.DPS,
-        ) {
-          it
-        }
+
+    return maybeChangedReport.alsoIfChanged {
+      eventPublishAndAudit(
+        ReportDomainEventType.INCIDENT_REPORT_AMENDED,
+        InformationSource.DPS,
+      ) {
+        it
       }
-    }
+    }.value
   }
 
   @PatchMapping("/{id}/type")
@@ -522,18 +521,17 @@ class ReportResource(
     @Valid
     changeTypeRequest: ChangeTypeRequest,
   ): ReportWithDetails {
-    val (report, changed) = reportService.changeReportType(id, changeTypeRequest)
+    val maybeChangedReport = reportService.changeReportType(id, changeTypeRequest)
       ?: throw ReportNotFoundException(id)
-    return report.also {
-      if (changed) {
-        eventPublishAndAudit(
-          ReportDomainEventType.INCIDENT_REPORT_AMENDED,
-          InformationSource.DPS,
-        ) {
-          it
-        }
+
+    return maybeChangedReport.alsoIfChanged {
+      eventPublishAndAudit(
+        ReportDomainEventType.INCIDENT_REPORT_AMENDED,
+        InformationSource.DPS,
+      ) {
+        it
       }
-    }
+    }.value
   }
 
   // TODO: decide if a different role should be used!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/MaybeChangedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/MaybeChangedTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.utils.MaybeChanged
+
+@DisplayName("Maybe-changed values")
+class MaybeChangedTest {
+  @Test
+  fun `maybe-changed value calls block only if it was marked as changed`() {
+    val unchangedValue = MaybeChanged.Unchanged("some value that is marked as unchanged")
+    unchangedValue.alsoIfChanged {
+      fail("block should not be called on unchanged values")
+    }
+
+    val changedValue = MaybeChanged.Changed("some value that is marked as changed")
+    var blockCalled = false
+    changedValue.alsoIfChanged {
+      assertThat(it).isEqualTo("some value that is marked as changed")
+      blockCalled = true
+    }
+    assertThat(blockCalled).isTrue()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -761,7 +761,10 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         webTestClient.post().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue("{}")
+          .bodyValue(
+            // language=json
+            "{}",
+          )
           .exchange()
           .expectStatus().isBadRequest
 
@@ -992,7 +995,10 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         webTestClient.patch().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue("[]")
+          .bodyValue(
+            // language=json
+            "[]",
+          )
           .exchange()
           .expectStatus().isBadRequest
 
@@ -1533,6 +1539,9 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           )
           .exchange()
           .expectStatus().isBadRequest
+          .expectBody().jsonPath("developerMessage").value<String> {
+            assertThat(it).contains("Inactive incident type OLD_ASSAULT3")
+          }
 
         assertThatNoDomainEventsWereSent()
       }
@@ -2069,8 +2078,16 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         @TestFactory
         fun `cannot add invalid object to a report`(): List<DynamicTest> {
           val requests = mutableListOf(
-            InvalidRequestTestCase("empty request", "{}"),
-            InvalidRequestTestCase("invalid shape", "[]"),
+            InvalidRequestTestCase(
+              "empty request",
+              // language=json
+              "{}",
+            ),
+            InvalidRequestTestCase(
+              "invalid shape",
+              // language=json
+              "[]",
+            ),
           )
           requests.addAll(invalidRequests)
           return requests.map { (name, request) ->
@@ -2196,7 +2213,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         @TestFactory
         fun `cannot update related object with invalid payload`(): List<DynamicTest> {
           val requests = mutableListOf(
-            InvalidRequestTestCase("invalid shape", "[]"),
+            InvalidRequestTestCase(
+              "invalid shape",
+              // language=json
+              "[]",
+            ),
           )
           requests.addAll(invalidRequests)
           return requests.map { (name, request) ->
@@ -2229,7 +2250,10 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           webTestClient.patch().uri(url)
             .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
             .header("Content-Type", "application/json")
-            .bodyValue("{}")
+            .bodyValue(
+              // language=json
+              "{}",
+            )
             .exchange()
             .expectStatus().isOk
             .expectBody().json(
@@ -2296,7 +2320,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         @TestFactory
         fun `can update nullable properties`(): List<DynamicTest> {
           return nullablePropertyRequests.flatMap { testCase ->
-            testCase.testCases().map { (name, request, expectedFieldValue) ->
+            testCase.makeValidRequestTests().map { (name, request, expectedFieldValue) ->
               DynamicTest.dynamicTest(name) {
                 webTestClient.patch().uri(urlForFirstRelatedObject)
                   .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
@@ -2430,7 +2454,6 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     inner class UpdateObject : RelatedObjects.UpdateObject(
       invalidRequests = listOf(
         InvalidRequestTestCase(
-
           "short staff username",
           getResource("/related-objects/staff-involved/update-request-short-username.json"),
         ),
@@ -2573,7 +2596,7 @@ data class NullablePropertyTestCase(
     val expectedFieldValue: String?,
   )
 
-  fun testCases(): List<ValidRequestTestCase> = listOf(
+  fun makeValidRequestTests(): List<ValidRequestTestCase> = listOf(
     ValidRequestTestCase(
       "$field with not value provided",
       // language=json

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -1444,6 +1444,377 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
   }
 
+  @DisplayName("PATCH /incident-reports/{id}/type")
+  @Nested
+  inner class ChangeType {
+    private lateinit var urlWithNoQuestionsOrHistory: String
+
+    // language=json
+    private val validPayload = """
+      {"newType": "DAMAGE"}
+    """
+
+    @BeforeEach
+    fun setUp() {
+      urlWithNoQuestionsOrHistory = "/incident-reports/${existingReport.id}/type"
+    }
+
+    @DisplayName("is secured")
+    @Nested
+    inner class Security {
+      @DisplayName("by role and scope")
+      @TestFactory
+      fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+        webTestClient.patch().uri(urlWithNoQuestionsOrHistory).bodyValue(validPayload),
+        "MAINTAIN_INCIDENT_REPORTS",
+        "write",
+      )
+    }
+
+    @DisplayName("validates requests")
+    @Nested
+    inner class Validation {
+      @Test
+      fun `cannot change type of a missing report`() {
+        webTestClient.patch().uri("/incident-reports/11111111-2222-3333-4444-555555555555/type")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(validPayload)
+          .exchange()
+          .expectStatus().isNotFound
+
+        assertThatNoDomainEventsWereSent()
+      }
+
+      @Test
+      fun `cannot change type of a report with invalid payload`() {
+        webTestClient.patch().uri(urlWithNoQuestionsOrHistory)
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            // language=json
+            """
+              {"type": "DAMAGE"}
+            """,
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+
+        assertThatNoDomainEventsWereSent()
+      }
+
+      @Test
+      fun `cannot change type of a report to an unknown one`() {
+        webTestClient.patch().uri(urlWithNoQuestionsOrHistory)
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            // language=json
+            """
+              {"newType": "MISSING_TYPE"}
+            """,
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+
+        assertThatNoDomainEventsWereSent()
+      }
+
+      @Test
+      fun `cannot change type of a report to inactive one`() {
+        webTestClient.patch().uri(urlWithNoQuestionsOrHistory)
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            // language=json
+            """
+              {"newType": "OLD_ASSAULT3"}
+            """,
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+
+        assertThatNoDomainEventsWereSent()
+      }
+    }
+
+    @DisplayName("works")
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `can change type of a report but keeping it the same`() {
+        val reportWithQuestions = reportRepository.save(
+          buildIncidentReport(
+            incidentNumber = "IR-0000000001124146",
+            reportTime = now.minusMinutes(3),
+            status = Status.AWAITING_ANALYSIS,
+            generateQuestions = 2,
+            generateResponses = 2,
+            generateHistory = 0,
+          ),
+        )
+        webTestClient.patch().uri("/incident-reports/${reportWithQuestions.id}/type")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            // language=json
+            """
+              {"newType": "FINDS"}
+            """,
+          )
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+            {
+              "id": "${reportWithQuestions.id}",
+              "incidentNumber": "IR-0000000001124146",
+              "type": "FINDS",
+              "incidentDateAndTime": "2023-12-05T11:31:56",
+              "prisonId": "MDI",
+              "title": "Incident Report IR-0000000001124146",
+              "description": "A new incident created in the new service of type Finds",
+              "reportedBy": "USER1",
+              "reportedAt": "2023-12-05T12:31:56",
+              "status": "AWAITING_ANALYSIS",
+              "assignedTo": "USER1",
+              "createdAt": "2023-12-05T12:31:56",
+              "modifiedAt": "2023-12-05T12:31:56",
+              "modifiedBy": "USER1",
+              "createdInNomis": false,
+              "history": [],
+              "questions": [
+                {
+                  "code": "QID-000000000001",
+                  "question": "Question #1",
+                  "additionalInformation": "Explanation #1",
+                  "responses": [
+                    {
+                      "response": "Response #1",
+                      "additionalInformation": "Prose #1",
+                      "recordedBy": "some-user",
+                      "recordedAt": "2023-12-05T12:31:56"
+                    },
+                    {
+                      "response": "Response #2",
+                      "additionalInformation": "Prose #2",
+                      "recordedBy": "some-user",
+                      "recordedAt": "2023-12-05T12:31:56"
+                    }
+                  ]
+                },
+                {
+                  "code": "QID-000000000002",
+                  "question": "Question #2",
+                  "additionalInformation": "Explanation #2",
+                  "responses": [
+                    {
+                      "response": "Response #1",
+                      "additionalInformation": "Prose #1",
+                      "recordedBy": "some-user",
+                      "recordedAt": "2023-12-05T12:31:56"
+                    },
+                    {
+                      "response": "Response #2",
+                      "additionalInformation": "Prose #2",
+                      "recordedBy": "some-user",
+                      "recordedAt": "2023-12-05T12:31:56"
+                    }
+                  ]
+                }
+              ]
+            }
+            """,
+            false,
+          )
+
+        assertThatNoDomainEventsWereSent()
+      }
+
+      @Test
+      fun `can change type of a report creating history when there was none`() {
+        val reportWithQuestions = reportRepository.save(
+          buildIncidentReport(
+            incidentNumber = "IR-0000000001124146",
+            reportTime = now.minusMinutes(3),
+            status = Status.AWAITING_ANALYSIS,
+            generateQuestions = 2,
+            generateResponses = 2,
+            generateHistory = 0,
+          ),
+        )
+        webTestClient.patch().uri("/incident-reports/${reportWithQuestions.id}/type")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(validPayload)
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+            {
+              "id": "${reportWithQuestions.id}",
+              "incidentNumber": "IR-0000000001124146",
+              "type": "DAMAGE",
+              "incidentDateAndTime": "2023-12-05T11:31:56",
+              "prisonId": "MDI",
+              "title": "Incident Report IR-0000000001124146",
+              "description": "A new incident created in the new service of type Finds",
+              "reportedBy": "USER1",
+              "reportedAt": "2023-12-05T12:31:56",
+              "status": "AWAITING_ANALYSIS",
+              "assignedTo": "USER1",
+              "createdAt": "2023-12-05T12:31:56",
+              "modifiedAt": "2023-12-05T12:34:56",
+              "modifiedBy": "INCIDENT_REPORTING_API",
+              "createdInNomis": false,
+              "history": [
+                {
+                  "type": "FINDS",
+                  "changedAt": "2023-12-05T12:34:56",
+                  "changedBy": "INCIDENT_REPORTING_API",
+                  "questions": [
+                    {
+                      "code": "QID-000000000001",
+                      "question": "Question #1",
+                      "additionalInformation": "Explanation #1",
+                      "responses": [
+                        {
+                          "response": "Response #1",
+                          "additionalInformation": "Prose #1",
+                          "recordedBy": "some-user",
+                          "recordedAt": "2023-12-05T12:31:56"
+                        },
+                        {
+                          "response": "Response #2",
+                          "additionalInformation": "Prose #2",
+                          "recordedBy": "some-user",
+                          "recordedAt": "2023-12-05T12:31:56"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "QID-000000000002",
+                      "question": "Question #2",
+                      "additionalInformation": "Explanation #2",
+                      "responses": [
+                        {
+                          "response": "Response #1",
+                          "additionalInformation": "Prose #1",
+                          "recordedBy": "some-user",
+                          "recordedAt": "2023-12-05T12:31:56"
+                        },
+                        {
+                          "response": "Response #2",
+                          "additionalInformation": "Prose #2",
+                          "recordedBy": "some-user",
+                          "recordedAt": "2023-12-05T12:31:56"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "questions": []
+            }
+            """,
+            false,
+          )
+
+        assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+      }
+
+      @Test
+      fun `can change type of a report preserving history when it already existed`() {
+        val reportWithQuestionsAndHistory = reportRepository.save(
+          buildIncidentReport(
+            incidentNumber = "IR-0000000001124146",
+            reportTime = now.minusMinutes(3),
+            status = Status.AWAITING_ANALYSIS,
+            generateQuestions = 1,
+            generateResponses = 1,
+            generateHistory = 1,
+          ),
+        )
+        webTestClient.patch().uri("/incident-reports/${reportWithQuestionsAndHistory.id}/type")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(validPayload)
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+            {
+              "id": "${reportWithQuestionsAndHistory.id}",
+              "incidentNumber": "IR-0000000001124146",
+              "type": "DAMAGE",
+              "incidentDateAndTime": "2023-12-05T11:31:56",
+              "prisonId": "MDI",
+              "title": "Incident Report IR-0000000001124146",
+              "description": "A new incident created in the new service of type Finds",
+              "reportedBy": "USER1",
+              "reportedAt": "2023-12-05T12:31:56",
+              "status": "AWAITING_ANALYSIS",
+              "assignedTo": "USER1",
+              "createdAt": "2023-12-05T12:31:56",
+              "modifiedAt": "2023-12-05T12:34:56",
+              "modifiedBy": "INCIDENT_REPORTING_API",
+              "createdInNomis": false,
+              "history": [
+                {
+                  "type": "ASSAULT",
+                  "changedAt": "2023-12-05T12:31:56",
+                  "changedBy": "some-past-user",
+                  "questions": [
+                    {
+                      "code": "QID-1-000000000001",
+                      "question": "Historical question #1-1",
+                      "additionalInformation": "Explanation #1 in history #1",
+                      "responses": [
+                        {
+                          "response": "Historical response #1-1",
+                          "additionalInformation": "Prose #1 in history #1",
+                          "recordedBy": "some-user",
+                          "recordedAt": "2023-12-05T12:31:56"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "FINDS",
+                  "changedAt": "2023-12-05T12:34:56",
+                  "changedBy": "INCIDENT_REPORTING_API",
+                  "questions": [
+                    {
+                      "code": "QID-000000000001",
+                      "question": "Question #1",
+                      "additionalInformation": "Explanation #1",
+                      "responses": [
+                        {
+                          "response": "Response #1",
+                          "additionalInformation": "Prose #1",
+                          "recordedBy": "some-user",
+                          "recordedAt": "2023-12-05T12:31:56"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "questions": []
+            }
+            """,
+            false,
+          )
+
+        assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+      }
+    }
+  }
+
   @DisplayName("DELETE /incident-reports/{id}")
   @Nested
   inner class DeleteReportById {


### PR DESCRIPTION
Changing a report’s status or type has a side effect of preserving the history, so there are now separate endpoints from the generic PATCH report method.

Changing a type to an inactive one is not allowed.

We still do not know what the lifecycle of a report is so there is no restriction on what transitions are allowed for status. Should the api permit any status change? Should it instead check the user’s role and disallow some? For instance, perhaps only QAs or central support can re-open a report once it has been closed.