### PR TITLE
IR-292: CRUD API endpoints for questions and responses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
 
@@ -10,8 +11,11 @@ data class AddQuestionWithResponses(
   @field:Size(max = 60)
   val code: String,
   @Schema(description = "The question", required = true)
+  @field:Size(min = 1)
   val question: String,
   @Schema(description = "The responses to this question", required = true)
+  @field:Valid
+  @field:Size(min = 1)
   val responses: List<AddQuestionResponse>,
   @Schema(description = "Optional additional information", required = false, defaultValue = "null")
   val additionalInformation: String? = null,
@@ -19,6 +23,7 @@ data class AddQuestionWithResponses(
 
 data class AddQuestionResponse(
   @Schema(description = "The response", required = true)
+  @field:Size(min = 1)
   val response: String,
   @Schema(description = "Username of person who responded to the question", required = true)
   @field:Size(min = 3, max = 120)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+
+@Schema(description = "Payload to add question with responses to an incident report")
+data class AddQuestionWithResponses(
+  @Schema(description = "The question code", required = true)
+  @field:Size(max = 60)
+  val code: String,
+  @Schema(description = "The question", required = true)
+  val question: String,
+  @Schema(description = "The responses to this question", required = true)
+  val responses: List<AddQuestionResponse>,
+  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  val additionalInformation: String? = null,
+)
+
+data class AddQuestionResponse(
+  @Schema(description = "The response", required = true)
+  val response: String,
+  @Schema(description = "Username of person who responded to the question", required = true)
+  @field:Size(min = 3, max = 120)
+  val recordedBy: String,
+  @Schema(description = "When the response was made", required = true, example = "2024-04-29T12:34:56.789012")
+  val recordedAt: LocalDateTime,
+  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  val additionalInformation: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
@@ -34,7 +34,6 @@ data class CreateReportRequest(
   val reportedBy: String,
   @Schema(description = "When the incident report was created", required = true, example = "2024-04-29T12:34:56.789012")
   val reportedAt: LocalDateTime,
-  // TODO: there is not yet a way to add any more details to a report, question-response pairs, etc
 ) {
   fun validate() {
     if (!createNewEvent && linkedEventId.isNullOrEmpty()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
@@ -22,7 +22,9 @@ class Question(
   @ManyToOne(fetch = FetchType.LAZY)
   private val report: Report,
 
+  // TODO: decide how this works and if it is ever unique (eg within 1 report)
   val code: String,
+
   val question: String,
 
   val additionalInformation: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -149,6 +149,8 @@ class Report(
 
   fun getQuestions(): List<Question> = questions
 
+  fun popLastQuestion(): Question? = questions.removeLastOrNull()
+
   fun changeType(newType: Type, changedAt: LocalDateTime, changedBy: String): Report {
     copyToHistory(changedAt, changedBy)
     questions.clear()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
@@ -162,7 +162,14 @@ class ReportQuestionResponseResource(
     @PathVariable
     reportId: UUID,
   ): List<Question> {
-    return reportService.deleteLastQuestionAndResponses(reportId)
+    val (report, questions) = reportService.deleteLastQuestionAndResponses(reportId)
       ?: throw ReportNotFoundException(reportId)
+    eventPublishAndAudit(
+      ReportDomainEventType.INCIDENT_REPORT_AMENDED,
+      InformationSource.DPS,
+    ) {
+      report
+    }
+    return questions
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
@@ -42,7 +42,7 @@ class ReportQuestionResponseResource(
     responses = [
       ApiResponse(
         responseCode = "200",
-        description = "Returns questions and responses",
+        description = "Returns all questions and responses in report",
       ),
       ApiResponse(
         responseCode = "401",
@@ -79,7 +79,7 @@ class ReportQuestionResponseResource(
     responses = [
       ApiResponse(
         responseCode = "201",
-        description = "Returns created question with responses",
+        description = "Returns all questions and responses in report",
       ),
       ApiResponse(
         responseCode = "400",
@@ -110,8 +110,9 @@ class ReportQuestionResponseResource(
     @RequestBody
     @Valid
     addQuestionWithResponses: AddQuestionWithResponses,
-  ): Question {
-    TODO("stub")
+  ): List<Question> {
+    return reportService.addQuestionWithResponses(reportId, addQuestionWithResponses)
+      ?: throw ReportNotFoundException(reportId)
   }
 
   @DeleteMapping("")
@@ -123,7 +124,7 @@ class ReportQuestionResponseResource(
     responses = [
       ApiResponse(
         responseCode = "200",
-        description = "Returns deleted question",
+        description = "Returns all questions and responses in report",
       ),
       ApiResponse(
         responseCode = "400",
@@ -151,7 +152,7 @@ class ReportQuestionResponseResource(
     @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
     @PathVariable
     reportId: UUID,
-  ): Question {
+  ): List<Question> {
     TODO("stub")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Question
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddQuestionWithResponses
+import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportService
 import java.util.UUID
 
 @RestController
@@ -29,7 +30,9 @@ import java.util.UUID
   name = "Questions and responses forming an incident report",
   description = "Create, retrieve and delete question-response pairs that form incident reports",
 )
-class ReportQuestionResponseResource : EventBaseResource() {
+class ReportQuestionResponseResource(
+  private val reportService: ReportService,
+) : EventBaseResource() {
   @GetMapping
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
@@ -63,7 +66,8 @@ class ReportQuestionResponseResource : EventBaseResource() {
     @PathVariable
     reportId: UUID,
   ): List<Question> {
-    TODO("stub")
+    return reportService.getQuestionsWithResponses(reportId)
+      ?: throw ReportNotFoundException(reportId)
   }
 
   @PostMapping("")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
@@ -18,8 +18,10 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Question
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddQuestionWithResponses
+import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportDomainEventType
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportService
 import java.util.UUID
 
@@ -111,8 +113,15 @@ class ReportQuestionResponseResource(
     @Valid
     addQuestionWithResponses: AddQuestionWithResponses,
   ): List<Question> {
-    return reportService.addQuestionWithResponses(reportId, addQuestionWithResponses)
+    val (report, questions) = reportService.addQuestionWithResponses(reportId, addQuestionWithResponses)
       ?: throw ReportNotFoundException(reportId)
+    eventPublishAndAudit(
+      ReportDomainEventType.INCIDENT_REPORT_AMENDED,
+      InformationSource.DPS,
+    ) {
+      report
+    }
+    return questions
   }
 
   @DeleteMapping("")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.Question
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddQuestionWithResponses
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportDomainEventType
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportService
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.util.UUID
 
 @RestController
@@ -118,6 +119,7 @@ class ReportQuestionResponseResource(
     eventPublishAndAudit(
       ReportDomainEventType.INCIDENT_REPORT_AMENDED,
       InformationSource.DPS,
+      WhatChanged.QUESTIONS,
     ) {
       report
     }
@@ -167,6 +169,7 @@ class ReportQuestionResponseResource(
     eventPublishAndAudit(
       ReportDomainEventType.INCIDENT_REPORT_AMENDED,
       InformationSource.DPS,
+      WhatChanged.QUESTIONS,
     ) {
       report
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
@@ -1,0 +1,153 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.Question
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddQuestionWithResponses
+import java.util.UUID
+
+@RestController
+@Validated
+@RequestMapping("/incident-reports/{reportId}/questions", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Tag(
+  name = "Questions and responses forming an incident report",
+  description = "Create, retrieve and delete question-response pairs that form incident reports",
+)
+class ReportQuestionResponseResource : EventBaseResource() {
+  @GetMapping
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
+  @Operation(
+    summary = "Returns all non-historic questions in an incident report with their responses",
+    description = "Requires role VIEW_INCIDENT_REPORTS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns questions and responses",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the VIEW_INCIDENT_REPORTS role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getQuestionsAndResponses(
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @PathVariable
+    reportId: UUID,
+  ): List<Question> {
+    TODO("stub")
+  }
+
+  @PostMapping("")
+  @PreAuthorize("hasRole('ROLE_MAINTAIN_INCIDENT_REPORTS') and hasAuthority('SCOPE_write')")
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(
+    summary = "Adds a new question with responses to the end of the list",
+    description = "Requires role MAINTAIN_INCIDENT_REPORTS and write scope",
+    responses = [
+      ApiResponse(
+        responseCode = "201",
+        description = "Returns created question with responses",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MAINTAIN_INCIDENT_REPORTS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun addQuestionWithResponses(
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @PathVariable
+    reportId: UUID,
+    @RequestBody
+    @Valid
+    addQuestionWithResponses: AddQuestionWithResponses,
+  ): Question {
+    TODO("stub")
+  }
+
+  @DeleteMapping("")
+  @PreAuthorize("hasRole('ROLE_MAINTAIN_INCIDENT_REPORTS') and hasAuthority('SCOPE_write')")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Deletes the last question from an incident report along with its responses",
+    description = "Requires role MAINTAIN_INCIDENT_REPORTS and write scope",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns deleted question",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MAINTAIN_INCIDENT_REPORTS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun deleteLastQuestionAndResponses(
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @PathVariable
+    reportId: UUID,
+  ): Question {
+    TODO("stub")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
@@ -162,6 +162,7 @@ class ReportQuestionResponseResource(
     @PathVariable
     reportId: UUID,
   ): List<Question> {
-    TODO("stub")
+    return reportService.deleteLastQuestionAndResponses(reportId)
+      ?: throw ReportNotFoundException(reportId)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.service
 
 import com.microsoft.applicationinsights.TelemetryClient
+import jakarta.validation.ValidationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
@@ -296,6 +297,7 @@ class ReportService(
   fun deleteLastQuestionAndResponses(reportId: UUID): List<Question>? {
     return reportRepository.findOneEagerlyById(reportId)?.run {
       popLastQuestion()
+        ?: throw ValidationException("Question list is empty")
       getQuestions().map { it.toDto() }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -291,4 +291,12 @@ class ReportService(
       reportBasic to getQuestions().map { it.toDto() }
     }
   }
+
+  @Transactional
+  fun deleteLastQuestionAndResponses(reportId: UUID): List<Question>? {
+    return reportRepository.findOneEagerlyById(reportId)?.run {
+      popLastQuestion()
+      getQuestions().map { it.toDto() }
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -251,7 +251,7 @@ class ReportService(
   }
 
   fun getQuestionsWithResponses(reportId: UUID): List<Question>? {
-    return reportRepository.findById(reportId).getOrNull()?.run {
+    return reportRepository.findOneEagerlyById(reportId)?.run {
       getQuestions().map { it.toDto() }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.config.trackEvent
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.Question
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.ReportBasic
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.ReportWithDetails
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.ChangeStatusRequest
@@ -246,6 +247,12 @@ class ReportService(
           reportWithDetails,
         )
       }
+    }
+  }
+
+  fun getQuestionsWithResponses(reportId: UUID): List<Question>? {
+    return reportRepository.findById(reportId).getOrNull()?.run {
+      getQuestions().map { it.toDto() }
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Question
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.ReportBasic
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.ReportWithDetails
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddQuestionWithResponses
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.ChangeStatusRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.ChangeTypeRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.CreateReportRequest
@@ -252,6 +253,29 @@ class ReportService(
 
   fun getQuestionsWithResponses(reportId: UUID): List<Question>? {
     return reportRepository.findOneEagerlyById(reportId)?.run {
+      getQuestions().map { it.toDto() }
+    }
+  }
+
+  @Transactional
+  fun addQuestionWithResponses(reportId: UUID, addRequest: AddQuestionWithResponses): List<Question>? {
+    return reportRepository.findOneEagerlyById(reportId)?.run {
+      with(
+        addQuestion(
+          code = addRequest.code,
+          question = addRequest.question,
+          additionalInformation = addRequest.additionalInformation,
+        ),
+      ) {
+        addRequest.responses.forEach {
+          addResponse(
+            response = it.response,
+            recordedBy = it.recordedBy,
+            recordedAt = it.recordedAt,
+            additionalInformation = it.additionalInformation,
+          )
+        }
+      }
       getQuestions().map { it.toDto() }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SnsService.kt
@@ -65,18 +65,29 @@ class SnsService(
   }
 }
 
+@Suppress("ktlint:standard:spacing-between-declarations-with-comments")
 enum class WhatChanged {
-  BASIC_REPORT, // changes to a Report's basic information
-  ANYTHING, // anything in the report potentially changed
-  TYPE, // change to the report type
-  STATUS, // change to the report status
+  /** Anything in the report potentially changed */
+  ANYTHING,
+  /** Changes to a report’s basic information */
+  BASIC_REPORT,
+  /** Report type changed */
+  TYPE,
+  /** Report status changed */
+  STATUS,
+
+  /** Added, updated or deleted an involved prisoner */
   PRISONERS_INVOLVED,
+  /** Added, updated or deleted an involved member of staff */
   STAFF_INVOLVED,
+  /** Added, updated or deleted a location */
   LOCATIONS,
+  /** Added, updated or deleted evidence */
   EVIDENCE,
+  /** Added, updated or deleted a correction request */
   CORRECTION_REQUESTS,
 
-  // TODO: Just questions? Questions/answers? Endpoint not there yet
+  /** Added or deleted a question with responses */
   QUESTIONS,
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -2829,6 +2829,20 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatNoDomainEventsWereSent()
         }
+
+        @Test
+        fun `cannot delete question from a report when the question list is empty`() {
+          webTestClient.delete().uri(urlWithoutQuestions)
+            .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
+            .header("Content-Type", "application/json")
+            .exchange()
+            .expectStatus().isBadRequest
+            .expectBody().jsonPath("developerMessage").value<String> {
+              assertThat(it).contains("Question list is empty")
+            }
+
+          assertThatNoDomainEventsWereSent()
+        }
       }
 
       @DisplayName("works")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -2578,6 +2578,66 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     @Nested
     inner class RemoveObject : RelatedObjects.RemoveObject()
   }
+
+  @DisplayName("Questions with responses")
+  @Nested
+  inner class QuestionsWithResponses {
+    private lateinit var url: String
+
+    @BeforeEach
+    fun setUp() {
+      url = "/incident-reports/${existingReport.id}/questions"
+    }
+
+    @DisplayName("GET /incident-reports/{reportId}/questions")
+    @Nested
+    inner class List {
+      @DisplayName("is secured")
+      @Nested
+      inner class Security {
+        @DisplayName("by role and scope")
+        @TestFactory
+        fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+          webTestClient.get().uri(url),
+          "VIEW_INCIDENT_REPORTS",
+        )
+      }
+    }
+
+    @DisplayName("POST /incident-reports/{reportId}/questions")
+    @Nested
+    inner class Add {
+      private val validRequest = getResource("/questions-with-responses/add-request-with-responses.json")
+
+      @DisplayName("is secured")
+      @Nested
+      inner class Security {
+        @DisplayName("by role and scope")
+        @TestFactory
+        fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+          webTestClient.post().uri(url).bodyValue(validRequest),
+          "MAINTAIN_INCIDENT_REPORTS",
+          "write",
+        )
+      }
+    }
+
+    @DisplayName("DELETE /incident-reports/{reportId}/questions")
+    @Nested
+    inner class Delete {
+      @DisplayName("is secured")
+      @Nested
+      inner class Security {
+        @DisplayName("by role and scope")
+        @TestFactory
+        fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+          webTestClient.delete().uri(url),
+          "MAINTAIN_INCIDENT_REPORTS",
+          "write",
+        )
+      }
+    }
+  }
 }
 
 data class InvalidRequestTestCase(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -2841,7 +2841,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReport.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124143")
+          assertThatDomainEventWasSent(
+            "incident.report.amended",
+            "IR-0000000001124143",
+            whatChanged = WhatChanged.QUESTIONS,
+          )
         }
 
         @Test
@@ -2860,7 +2864,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithQuestionsAndResponses.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent(
+            "incident.report.amended",
+            "IR-0000000001124146",
+            whatChanged = WhatChanged.QUESTIONS,
+          )
         }
 
         @Test
@@ -2880,7 +2888,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithQuestionsAndResponses.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent(
+            "incident.report.amended",
+            "IR-0000000001124146",
+            whatChanged = WhatChanged.QUESTIONS,
+          )
         }
       }
     }
@@ -2947,7 +2959,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithQuestionsAndResponses.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent(
+            "incident.report.amended",
+            "IR-0000000001124146",
+            whatChanged = WhatChanged.QUESTIONS,
+          )
         }
 
         @Test
@@ -2958,7 +2974,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             .exchange()
             .expectStatus().isOk
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent(
+            "incident.report.amended",
+            "IR-0000000001124146",
+            whatChanged = WhatChanged.QUESTIONS,
+          )
 
           webTestClient.delete().uri(urlWithQuestionsAndResponses)
             .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
@@ -2973,7 +2993,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithQuestionsAndResponses.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent(
+            "incident.report.amended",
+            "IR-0000000001124146",
+            whatChanged = WhatChanged.QUESTIONS,
+          )
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -2857,6 +2857,10 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             .exchange()
             .expectStatus().isOk
             .expectBody().json(expectedResponse, true)
+
+          assertThatReportWasModified(existingReportWithQuestionsAndResponses.id!!)
+
+          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
         }
 
         @Test
@@ -2866,6 +2870,9 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             .header("Content-Type", "application/json")
             .exchange()
             .expectStatus().isOk
+
+          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+
           webTestClient.delete().uri(urlWithQuestionsAndResponses)
             .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
             .header("Content-Type", "application/json")
@@ -2876,6 +2883,10 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "[]",
               true,
             )
+
+          assertThatReportWasModified(existingReportWithQuestionsAndResponses.id!!)
+
+          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
         }
       }
     }

--- a/src/test/resources/questions-with-responses/add-request-empty-question.json
+++ b/src/test/resources/questions-with-responses/add-request-empty-question.json
@@ -1,0 +1,19 @@
+{
+  "code": "QID-000000002001",
+  "question": "",
+  "additionalInformation": "Amounts do not matter",
+  "responses": [
+    {
+      "response": "Note with phone number",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "020 1111 2222"
+    },
+    {
+      "response": "Mobile phone",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "Not a smartphone"
+    }
+  ]
+}

--- a/src/test/resources/questions-with-responses/add-request-empty-response.json
+++ b/src/test/resources/questions-with-responses/add-request-empty-response.json
@@ -1,0 +1,19 @@
+{
+  "code": "QID-000000002001",
+  "question": "List every “find”",
+  "additionalInformation": "Amounts do not matter",
+  "responses": [
+    {
+      "response": "Note with phone number",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "020 1111 2222"
+    },
+    {
+      "response": "",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "Mobile phone"
+    }
+  ]
+}

--- a/src/test/resources/questions-with-responses/add-request-long-code.json
+++ b/src/test/resources/questions-with-responses/add-request-long-code.json
@@ -1,0 +1,19 @@
+{
+  "code": "1234567890123456789012345678901234567890123456789012345678901",
+  "question": "List every “find”",
+  "additionalInformation": "Amounts do not matter",
+  "responses": [
+    {
+      "response": "Note with phone number",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "020 1111 2222"
+    },
+    {
+      "response": "Mobile phone",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "Not a smartphone"
+    }
+  ]
+}

--- a/src/test/resources/questions-with-responses/add-request-short-staff-username.json
+++ b/src/test/resources/questions-with-responses/add-request-short-staff-username.json
@@ -1,0 +1,19 @@
+{
+  "code": "QID-000000002001",
+  "question": "List every “find”",
+  "additionalInformation": "Amounts do not matter",
+  "responses": [
+    {
+      "response": "Note with phone number",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "020 1111 2222"
+    },
+    {
+      "response": "Mobile phone",
+      "recordedBy": "2",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "Not a smartphone"
+    }
+  ]
+}

--- a/src/test/resources/questions-with-responses/add-request-with-responses-and-null-fields.json
+++ b/src/test/resources/questions-with-responses/add-request-with-responses-and-null-fields.json
@@ -1,0 +1,18 @@
+{
+  "code": "QID-000000002001",
+  "question": "List every “find”",
+  "additionalInformation": null,
+  "responses": [
+    {
+      "response": "Note with phone number",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56"
+    },
+    {
+      "response": "Mobile phone",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": null
+    }
+  ]
+}

--- a/src/test/resources/questions-with-responses/add-request-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-request-with-responses.json
@@ -1,0 +1,19 @@
+{
+  "code": "QID-000000002001",
+  "question": "List every “find”",
+  "additionalInformation": "Amounts do not matter",
+  "responses": [
+    {
+      "response": "Note with phone number",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "020 1111 2222"
+    },
+    {
+      "response": "Mobile phone",
+      "recordedBy": "responding-user",
+      "recordedAt": "2023-12-05T12:34:56",
+      "additionalInformation": "Not a smartphone"
+    }
+  ]
+}

--- a/src/test/resources/questions-with-responses/add-request-without-responses.json
+++ b/src/test/resources/questions-with-responses/add-request-without-responses.json
@@ -1,0 +1,6 @@
+{
+  "code": "QID-000000002001",
+  "question": "List every “find”",
+  "additionalInformation": "Amounts do not matter",
+  "responses": []
+}

--- a/src/test/resources/questions-with-responses/add-response-with-responses-and-null-fields.json
+++ b/src/test/resources/questions-with-responses/add-response-with-responses-and-null-fields.json
@@ -1,0 +1,59 @@
+[
+  {
+    "code": "QID-000000000001",
+    "question": "Question #1",
+    "responses": [
+      {
+        "response": "Response #1",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #1"
+      },
+      {
+        "response": "Response #2",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #2"
+      }
+    ],
+    "additionalInformation": "Explanation #1"
+  },
+  {
+    "code": "QID-000000000002",
+    "question": "Question #2",
+    "responses": [
+      {
+        "response": "Response #1",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #1"
+      },
+      {
+        "response": "Response #2",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #2"
+      }
+    ],
+    "additionalInformation": "Explanation #2"
+  },
+  {
+    "code": "QID-000000002001",
+    "question": "List every “find”",
+    "additionalInformation": null,
+    "responses": [
+      {
+        "response": "Note with phone number",
+        "recordedBy": "responding-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": null
+      },
+      {
+        "response": "Mobile phone",
+        "recordedBy": "responding-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": null
+      }
+    ]
+  }
+]

--- a/src/test/resources/questions-with-responses/add-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-with-responses.json
@@ -1,0 +1,59 @@
+[
+  {
+    "code": "QID-000000000001",
+    "question": "Question #1",
+    "responses": [
+      {
+        "response": "Response #1",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #1"
+      },
+      {
+        "response": "Response #2",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #2"
+      }
+    ],
+    "additionalInformation": "Explanation #1"
+  },
+  {
+    "code": "QID-000000000002",
+    "question": "Question #2",
+    "responses": [
+      {
+        "response": "Response #1",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #1"
+      },
+      {
+        "response": "Response #2",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #2"
+      }
+    ],
+    "additionalInformation": "Explanation #2"
+  },
+  {
+    "code": "QID-000000002001",
+    "question": "List every “find”",
+    "additionalInformation": "Amounts do not matter",
+    "responses": [
+      {
+        "response": "Note with phone number",
+        "recordedBy": "responding-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "020 1111 2222"
+      },
+      {
+        "response": "Mobile phone",
+        "recordedBy": "responding-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Not a smartphone"
+      }
+    ]
+  }
+]

--- a/src/test/resources/questions-with-responses/add-response-without-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-without-responses.json
@@ -1,0 +1,21 @@
+[
+  {
+    "code": "QID-000000002001",
+    "question": "List every “find”",
+    "additionalInformation": "Amounts do not matter",
+    "responses": [
+      {
+        "response": "Note with phone number",
+        "recordedBy": "responding-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "020 1111 2222"
+      },
+      {
+        "response": "Mobile phone",
+        "recordedBy": "responding-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Not a smartphone"
+      }
+    ]
+  }
+]

--- a/src/test/resources/questions-with-responses/delete-response.json
+++ b/src/test/resources/questions-with-responses/delete-response.json
@@ -1,0 +1,21 @@
+[
+  {
+    "code": "QID-000000000001",
+    "question": "Question #1",
+    "responses": [
+      {
+        "response": "Response #1",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #1"
+      },
+      {
+        "response": "Response #2",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #2"
+      }
+    ],
+    "additionalInformation": "Explanation #1"
+  }
+]

--- a/src/test/resources/questions-with-responses/list-response-with-several.json
+++ b/src/test/resources/questions-with-responses/list-response-with-several.json
@@ -1,0 +1,40 @@
+[
+  {
+    "code": "QID-000000000001",
+    "question": "Question #1",
+    "responses": [
+      {
+        "response": "Response #1",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #1"
+      },
+      {
+        "response": "Response #2",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #2"
+      }
+    ],
+    "additionalInformation": "Explanation #1"
+  },
+  {
+    "code": "QID-000000000002",
+    "question": "Question #2",
+    "responses": [
+      {
+        "response": "Response #1",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #1"
+      },
+      {
+        "response": "Response #2",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56",
+        "additionalInformation": "Prose #2"
+      }
+    ],
+    "additionalInformation": "Explanation #2"
+  }
+]


### PR DESCRIPTION
- Questions are always listed in order of insertion
    - …their responses are always listed in order of insertion
- Question and response IDs are not exposed
- A question can be added to a report if it has at least one response
- The last question (and all of its responses) can be deleted if it exists
- Because subsequent questions often depend on prior responses, you cannot modify any existing questions nor delete any but the last one
    - Should there be a need to modify something in the middle, it and all subsequent questions should be deleted and recreated as needed
---
<img width="467" alt="questions-api" src="https://github.com/ministryofjustice/hmpps-incident-reporting-api/assets/911238/2c8cbf71-9e37-4499-98fb-cddde07bda7e">