### PR TITLE
IRS-291: Domain events include an hint of what part of the report changed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventBaseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventBaseResource.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.incidentreporting.resource
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.ReportBasic
+import uk.gov.justice.digital.hmpps.incidentreporting.service.AdditionalInformation
 import uk.gov.justice.digital.hmpps.incidentreporting.service.EventPublishAndAuditService
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportDomainEventType
 
@@ -19,10 +20,12 @@ abstract class EventBaseResource {
     block().also { report ->
       eventPublishAndAuditService.publishEvent(
         eventType = event,
-        reportId = report.id,
-        incidentNumber = report.incidentNumber,
+        additionalInformation = AdditionalInformation(
+          id = report.id,
+          incidentNumber = report.incidentNumber,
+          source = informationSource,
+        ),
         auditData = report,
-        source = informationSource,
       )
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventBaseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventBaseResource.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.ReportBasic
 import uk.gov.justice.digital.hmpps.incidentreporting.service.AdditionalInformation
 import uk.gov.justice.digital.hmpps.incidentreporting.service.EventPublishAndAuditService
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportDomainEventType
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 
 abstract class EventBaseResource {
 
@@ -15,6 +16,7 @@ abstract class EventBaseResource {
   protected fun <T : ReportBasic> eventPublishAndAudit(
     event: ReportDomainEventType,
     informationSource: InformationSource,
+    whatChanged: WhatChanged? = null,
     block: () -> T,
   ): T =
     block().also { report ->
@@ -24,6 +26,7 @@ abstract class EventBaseResource {
           id = report.id,
           incidentNumber = report.incidentNumber,
           source = informationSource,
+          whatChanged = whatChanged,
         ),
         auditData = report,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportCorrectionRequestResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportCorrectionRequestResource.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.CorrectionRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddCorrectionRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.UpdateCorrectionRequest
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.util.UUID
 
 @RestController
@@ -105,7 +106,10 @@ class ReportCorrectionRequestResource : ReportRelatedObjectsResource<CorrectionR
     @Valid
     request: AddCorrectionRequest,
   ): List<CorrectionRequest> {
-    return reportId.updateReportOrThrowNotFound("Added correction request to incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Added correction request to incident report",
+      WhatChanged.CORRECTION_REQUESTS,
+    ) { report ->
       with(request) {
         report.addCorrectionRequest(
           correctionRequestedBy = correctionRequestedBy,
@@ -163,7 +167,10 @@ class ReportCorrectionRequestResource : ReportRelatedObjectsResource<CorrectionR
     @Valid
     request: UpdateCorrectionRequest,
   ): List<CorrectionRequest> {
-    return reportId.updateReportOrThrowNotFound("Updated a correction request in incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Updated a correction request in incident report",
+      WhatChanged.CORRECTION_REQUESTS,
+    ) { report ->
       val objects = report.correctionRequests
       objects.elementAtIndex(index).updateWith(request)
       objects.map { it.toDto() }
@@ -207,7 +214,10 @@ class ReportCorrectionRequestResource : ReportRelatedObjectsResource<CorrectionR
     @PathVariable
     index: Int,
   ): List<CorrectionRequest> {
-    return reportId.updateReportOrThrowNotFound("Deleted correction request from incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Deleted correction request from incident report",
+      WhatChanged.CORRECTION_REQUESTS,
+    ) { report ->
       val objects = report.correctionRequests
       objects.removeElementAtIndex(index)
       objects.map { it.toDto() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportEvidenceResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportEvidenceResource.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Evidence
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddEvidence
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.UpdateEvidence
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.util.UUID
 
 @RestController
@@ -105,7 +106,10 @@ class ReportEvidenceResource : ReportRelatedObjectsResource<Evidence, AddEvidenc
     @Valid
     request: AddEvidence,
   ): List<Evidence> {
-    return reportId.updateReportOrThrowNotFound("Added evidence to incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Added evidence to incident report",
+      WhatChanged.EVIDENCE,
+    ) { report ->
       with(request) {
         report.addEvidence(
           type = type,
@@ -161,7 +165,10 @@ class ReportEvidenceResource : ReportRelatedObjectsResource<Evidence, AddEvidenc
     @Valid
     request: UpdateEvidence,
   ): List<Evidence> {
-    return reportId.updateReportOrThrowNotFound("Updated evidence in incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Updated evidence in incident report",
+      WhatChanged.EVIDENCE,
+    ) { report ->
       val objects = report.evidence
       objects.elementAtIndex(index).updateWith(request)
       objects.map { it.toDto() }
@@ -205,7 +212,10 @@ class ReportEvidenceResource : ReportRelatedObjectsResource<Evidence, AddEvidenc
     @PathVariable
     index: Int,
   ): List<Evidence> {
-    return reportId.updateReportOrThrowNotFound("Deleted evidence from incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Deleted evidence from incident report",
+      WhatChanged.EVIDENCE,
+    ) { report ->
       val objects = report.evidence
       objects.removeElementAtIndex(index)
       objects.map { it.toDto() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportLocationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportLocationResource.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Location
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddLocation
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.UpdateLocation
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.util.UUID
 
 @RestController
@@ -105,7 +106,10 @@ class ReportLocationResource : ReportRelatedObjectsResource<Location, AddLocatio
     @Valid
     request: AddLocation,
   ): List<Location> {
-    return reportId.updateReportOrThrowNotFound("Added location to incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Added location to incident report",
+      WhatChanged.LOCATIONS,
+    ) { report ->
       with(request) {
         report.addLocation(
           locationId = locationId,
@@ -162,7 +166,10 @@ class ReportLocationResource : ReportRelatedObjectsResource<Location, AddLocatio
     @Valid
     request: UpdateLocation,
   ): List<Location> {
-    return reportId.updateReportOrThrowNotFound("Updated location in incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Updated location in incident report",
+      WhatChanged.LOCATIONS,
+    ) { report ->
       val objects = report.locations
       objects.elementAtIndex(index).updateWith(request)
       objects.map { it.toDto() }
@@ -206,7 +213,10 @@ class ReportLocationResource : ReportRelatedObjectsResource<Location, AddLocatio
     @PathVariable
     index: Int,
   ): List<Location> {
-    return reportId.updateReportOrThrowNotFound("Deleted location from incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Deleted location from incident report",
+      WhatChanged.LOCATIONS,
+    ) { report ->
       val objects = report.locations
       objects.removeElementAtIndex(index)
       objects.map { it.toDto() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportPrisonerInvolvementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportPrisonerInvolvementResource.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.PrisonerInvolvement
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddPrisonerInvolvement
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.UpdatePrisonerInvolvement
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.util.UUID
 
 @RestController
@@ -105,7 +106,10 @@ class ReportPrisonerInvolvementResource : ReportRelatedObjectsResource<PrisonerI
     @Valid
     request: AddPrisonerInvolvement,
   ): List<PrisonerInvolvement> {
-    return reportId.updateReportOrThrowNotFound("Added an involved prisoner to incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Added an involved prisoner to incident report",
+      WhatChanged.PRISONERS_INVOLVED,
+    ) { report ->
       with(request) {
         report.addPrisonerInvolved(
           prisonerNumber = prisonerNumber,
@@ -163,7 +167,10 @@ class ReportPrisonerInvolvementResource : ReportRelatedObjectsResource<PrisonerI
     @Valid
     request: UpdatePrisonerInvolvement,
   ): List<PrisonerInvolvement> {
-    return reportId.updateReportOrThrowNotFound("Updated an involved prisoner in incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Updated an involved prisoner in incident report",
+      WhatChanged.PRISONERS_INVOLVED,
+    ) { report ->
       val objects = report.prisonersInvolved
       objects.elementAtIndex(index).updateWith(request)
       objects.map { it.toDto() }
@@ -207,7 +214,10 @@ class ReportPrisonerInvolvementResource : ReportRelatedObjectsResource<PrisonerI
     @PathVariable
     index: Int,
   ): List<PrisonerInvolvement> {
-    return reportId.updateReportOrThrowNotFound("Deleted an involved prisoner from incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Deleted an involved prisoner from incident report",
+      WhatChanged.PRISONERS_INVOLVED,
+    ) { report ->
       val objects = report.prisonersInvolved
       objects.removeElementAtIndex(index)
       objects.map { it.toDto() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportRelatedObjectsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportRelatedObjectsResource.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportDomainEventType
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportService.Companion.log
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.time.Clock
 import java.time.LocalDateTime
 import java.util.UUID
@@ -41,7 +42,7 @@ abstract class ReportRelatedObjectsResource<ResponseDto, AddRequest, UpdateReque
       ?: throw ReportNotFoundException(this)
   }
 
-  protected fun <T> (UUID).updateReportOrThrowNotFound(changeMessage: String, block: (Report) -> T): T {
+  protected fun <T> (UUID).updateReportOrThrowNotFound(changeMessage: String, whatChanged: WhatChanged? = null, block: (Report) -> T): T {
     val report = findReportOrThrowNotFound()
     return block(report).also {
       report.modifiedAt = LocalDateTime.now(clock)
@@ -52,6 +53,7 @@ abstract class ReportRelatedObjectsResource<ResponseDto, AddRequest, UpdateReque
         // TODO: should different related object actions raise different events?
         ReportDomainEventType.INCIDENT_REPORT_AMENDED,
         InformationSource.DPS,
+        whatChanged,
       ) {
         basicReport
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportRelatedObjectsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportRelatedObjectsResource.kt
@@ -50,7 +50,6 @@ abstract class ReportRelatedObjectsResource<ResponseDto, AddRequest, UpdateReque
 
       val basicReport = report.toDtoBasic()
       eventPublishAndAudit(
-        // TODO: should different related object actions raise different events?
         ReportDomainEventType.INCIDENT_REPORT_AMENDED,
         InformationSource.DPS,
         whatChanged,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -476,6 +476,7 @@ class ReportResource(
       eventPublishAndAudit(
         ReportDomainEventType.INCIDENT_REPORT_AMENDED,
         InformationSource.DPS,
+        WhatChanged.STATUS,
       ) {
         it
       }
@@ -530,6 +531,7 @@ class ReportResource(
       eventPublishAndAudit(
         ReportDomainEventType.INCIDENT_REPORT_AMENDED,
         InformationSource.DPS,
+        WhatChanged.TYPE,
       ) {
         it
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.SimplePage
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.toSimplePage
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportDomainEventType
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportService
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.time.LocalDate
 import java.util.UUID
 
@@ -420,6 +421,7 @@ class ReportResource(
     return eventPublishAndAudit(
       ReportDomainEventType.INCIDENT_REPORT_AMENDED,
       InformationSource.DPS,
+      WhatChanged.BASIC_REPORT,
     ) {
       reportService.updateReport(id, updateReportRequest)
         ?: throw ReportNotFoundException(id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportStaffInvolvementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportStaffInvolvementResource.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.StaffInvolvement
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.AddStaffInvolvement
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.UpdateStaffInvolvement
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.util.UUID
 
 @RestController
@@ -105,7 +106,10 @@ class ReportStaffInvolvementResource : ReportRelatedObjectsResource<StaffInvolve
     @Valid
     request: AddStaffInvolvement,
   ): List<StaffInvolvement> {
-    return reportId.updateReportOrThrowNotFound("Added an involved member of staff to incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Added an involved member of staff to incident report",
+      WhatChanged.STAFF_INVOLVED,
+    ) { report ->
       with(request) {
         report.addStaffInvolved(
           staffUsername = staffUsername,
@@ -162,7 +166,10 @@ class ReportStaffInvolvementResource : ReportRelatedObjectsResource<StaffInvolve
     @Valid
     request: UpdateStaffInvolvement,
   ): List<StaffInvolvement> {
-    return reportId.updateReportOrThrowNotFound("Updated an involved member of staff in incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Updated an involved member of staff in incident report",
+      WhatChanged.STAFF_INVOLVED,
+    ) { report ->
       val objects = report.staffInvolved
       objects.elementAtIndex(index).updateWith(request)
       objects.map { it.toDto() }
@@ -206,7 +213,10 @@ class ReportStaffInvolvementResource : ReportRelatedObjectsResource<StaffInvolve
     @PathVariable
     index: Int,
   ): List<StaffInvolvement> {
-    return reportId.updateReportOrThrowNotFound("Deleted an involved member of staff from incident report") { report ->
+    return reportId.updateReportOrThrowNotFound(
+      "Deleted an involved member of staff from incident report",
+      WhatChanged.STAFF_INVOLVED,
+    ) { report ->
       val objects = report.staffInvolved
       objects.removeElementAtIndex(index)
       objects.map { it.toDto() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/EventPublishAndAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/EventPublishAndAuditService.kt
@@ -1,10 +1,8 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import java.time.Clock
 import java.time.LocalDateTime
-import java.util.UUID
 
 @Service
 class EventPublishAndAuditService(
@@ -15,22 +13,18 @@ class EventPublishAndAuditService(
 
   fun publishEvent(
     eventType: ReportDomainEventType,
-    reportId: UUID,
-    incidentNumber: String,
+    additionalInformation: AdditionalInformation,
     auditData: Any? = null,
-    source: InformationSource,
   ) {
     sendDomainEvent(
       eventType = eventType,
-      reportId = reportId,
-      incidentNumber = incidentNumber,
-      source = source,
+      additionalInformation = additionalInformation,
     )
 
     auditData?.let {
       sendAuditEvent(
         auditType = eventType.auditType,
-        id = reportId.toString(),
+        id = additionalInformation.id.toString(),
         auditData = it,
       )
     }
@@ -38,19 +32,13 @@ class EventPublishAndAuditService(
 
   private fun sendDomainEvent(
     eventType: ReportDomainEventType,
-    reportId: UUID,
-    incidentNumber: String,
-    source: InformationSource,
+    additionalInformation: AdditionalInformation,
   ) {
     snsService.publishDomainEvent(
       eventType = eventType,
-      description = "$reportId ${eventType.description}",
+      description = "${additionalInformation.id} ${eventType.description}",
       occurredAt = LocalDateTime.now(clock),
-      additionalInformation = AdditionalInformation(
-        id = reportId,
-        incidentNumber = incidentNumber,
-        source = source,
-      ),
+      additionalInformation = additionalInformation,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SnsService.kt
@@ -65,10 +65,26 @@ class SnsService(
   }
 }
 
+enum class WhatChanged {
+  BASIC_REPORT, // changes to a Report's basic information
+  ANYTHING, // anything in the report potentially changed
+  TYPE, // change to the report type
+  STATUS, // change to the report status
+  PRISONERS_INVOLVED,
+  STAFF_INVOLVED,
+  LOCATIONS,
+  EVIDENCE,
+  CORRECTION_REQUESTS,
+
+  // TODO: Just questions? Questions/answers? Endpoint not there yet
+  QUESTIONS,
+}
+
 data class AdditionalInformation(
   val id: UUID,
   val incidentNumber: String,
   val source: InformationSource,
+  val whatChanged: WhatChanged? = null,
 )
 
 data class HMPPSDomainEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/SqsIntegrationTestBase.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.config.SYSTEM_USERNAME
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
 import uk.gov.justice.digital.hmpps.incidentreporting.service.HMPPSDomainEvent
 import uk.gov.justice.digital.hmpps.incidentreporting.service.HMPPSMessage
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsSqsProperties
@@ -95,6 +96,7 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
     eventType: String,
     incidentNumber: String?,
     source: InformationSource = InformationSource.DPS,
+    whatChanged: WhatChanged? = null,
   ) {
     getDomainEvents(1).let {
       val event = it[0]
@@ -103,6 +105,7 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
         assertThat(event.additionalInformation?.incidentNumber).isEqualTo(incidentNumber)
       }
       assertThat(event.additionalInformation?.source).isEqualTo(source)
+      assertThat(event.additionalInformation?.whatChanged).isEqualTo(whatChanged)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.integration.SqsIntegration
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.time.Clock
 import java.time.LocalDate
 import java.util.UUID
@@ -1343,7 +1344,12 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
             )
           }
 
-        assertThatDomainEventWasSent("incident.report.amended", "$INCIDENT_NUMBER", InformationSource.NOMIS)
+        assertThatDomainEventWasSent(
+          "incident.report.amended",
+          "$INCIDENT_NUMBER",
+          InformationSource.NOMIS,
+          WhatChanged.ANYTHING,
+        )
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.integration.SqsIntegration
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
+import uk.gov.justice.digital.hmpps.incidentreporting.service.WhatChanged
 import java.time.Clock
 import java.util.UUID
 
@@ -1093,7 +1094,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             true,
           )
 
-        assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124143")
+        assertThatDomainEventWasSent(
+          "incident.report.amended",
+          "IR-0000000001124143",
+          InformationSource.DPS,
+          WhatChanged.BASIC_REPORT,
+        )
       }
 
       @Test
@@ -1136,7 +1142,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             true,
           )
 
-        assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124143")
+        assertThatDomainEventWasSent(
+          "incident.report.amended",
+          "IR-0000000001124143",
+          InformationSource.DPS,
+          WhatChanged.BASIC_REPORT,
+        )
       }
 
       @ParameterizedTest(name = "can update `{0}` of an incident report")
@@ -1210,7 +1221,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             true,
           )
 
-        assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124143")
+        assertThatDomainEventWasSent(
+          "incident.report.amended",
+          "IR-0000000001124143",
+          InformationSource.DPS,
+          WhatChanged.BASIC_REPORT,
+        )
       }
 
       @ParameterizedTest(name = "can propagate updates to parent event when requested: {0}")
@@ -1269,7 +1285,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           false,
         )
 
-        assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124143")
+        assertThatDomainEventWasSent(
+          "incident.report.amended",
+          "IR-0000000001124143",
+          InformationSource.DPS,
+          WhatChanged.BASIC_REPORT,
+        )
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -2515,7 +2515,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
   @DisplayName("Prisoner involvement")
   @Nested
-  inner class PrisonerInvolvement : RelatedObjects("prisoners-involved") {
+  inner class PrisonerInvolvement : RelatedObjects("prisoners-involved", WhatChanged.PRISONERS_INVOLVED) {
     @DisplayName("GET /incident-reports/{reportId}/prisoners-involved")
     @Nested
     inner class ListObjects : RelatedObjects.ListObjects()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -1466,7 +1466,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             false,
           )
 
-        assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124143")
+        assertThatDomainEventWasSent(
+          "incident.report.amended",
+          "IR-0000000001124143",
+          InformationSource.DPS,
+          WhatChanged.STATUS,
+        )
       }
     }
   }
@@ -1752,7 +1757,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             false,
           )
 
-        assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+        assertThatDomainEventWasSent(
+          "incident.report.amended",
+          "IR-0000000001124146",
+          InformationSource.DPS,
+          WhatChanged.TYPE,
+        )
       }
 
       @Test
@@ -1840,7 +1850,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             false,
           )
 
-        assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+        assertThatDomainEventWasSent(
+          "incident.report.amended",
+          "IR-0000000001124146",
+          InformationSource.DPS,
+          WhatChanged.TYPE,
+        )
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -2548,7 +2548,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
   @DisplayName("Locations")
   @Nested
-  inner class Locations : RelatedObjects("locations") {
+  inner class Locations : RelatedObjects("locations", WhatChanged.LOCATIONS) {
     @DisplayName("GET /incident-reports/{reportId}/locations")
     @Nested
     inner class ListObjects : RelatedObjects.ListObjects()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -2588,7 +2588,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
   @DisplayName("Correction requests")
   @Nested
-  inner class CorrectionRequests : RelatedObjects("correction-requests") {
+  inner class CorrectionRequests : RelatedObjects("correction-requests", WhatChanged.CORRECTION_REQUESTS) {
     @DisplayName("GET /incident-reports/{reportId}/correction-requests")
     @Nested
     inner class ListObjects : RelatedObjects.ListObjects()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -2568,7 +2568,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
   @DisplayName("Evidence")
   @Nested
-  inner class Evidence : RelatedObjects("evidence") {
+  inner class Evidence : RelatedObjects("evidence", WhatChanged.EVIDENCE) {
     @DisplayName("GET /incident-reports/{reportId}/evidence")
     @Nested
     inner class ListObjects : RelatedObjects.ListObjects()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -1970,7 +1970,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
   }
 
   @Nested
-  abstract inner class RelatedObjects(val urlSuffix: String) {
+  abstract inner class RelatedObjects(val urlSuffix: String, val whatChanged: WhatChanged? = null) {
     protected lateinit var existingReportWithRelatedObjects: Report
     protected lateinit var urlWithRelatedObjects: String
     protected lateinit var urlWithoutRelatedObjects: String
@@ -2157,7 +2157,12 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReport.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124143")
+          assertThatDomainEventWasSent(
+            "incident.report.amended",
+            "IR-0000000001124143",
+            InformationSource.DPS,
+            whatChanged,
+          )
         }
 
         @Test
@@ -2173,7 +2178,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithRelatedObjects.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146", InformationSource.DPS, whatChanged)
         }
       }
     }
@@ -2299,7 +2304,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithRelatedObjects.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146", InformationSource.DPS, whatChanged)
         }
 
         @ParameterizedTest(name = "can update {0} related object fully")
@@ -2324,7 +2329,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithRelatedObjects.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146", InformationSource.DPS, whatChanged)
         }
 
         @ParameterizedTest(name = "can update {0} related object partially")
@@ -2349,7 +2354,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithRelatedObjects.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146", InformationSource.DPS, whatChanged)
         }
 
         @DisplayName("can update nullable properties")
@@ -2446,7 +2451,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithRelatedObjects.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146", InformationSource.DPS, whatChanged)
         }
 
         @Test
@@ -2461,7 +2466,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
           assertThatReportWasModified(existingReportWithRelatedObjects.id!!)
 
-          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146")
+          assertThatDomainEventWasSent("incident.report.amended", "IR-0000000001124146", InformationSource.DPS, whatChanged)
         }
       }
     }
@@ -2469,7 +2474,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
   @DisplayName("Staff involvement")
   @Nested
-  inner class StaffInvolvement : RelatedObjects("staff-involved") {
+  inner class StaffInvolvement : RelatedObjects("staff-involved", WhatChanged.STAFF_INVOLVED) {
     @DisplayName("GET /incident-reports/{reportId}/staff-involved")
     @Nested
     inner class ListObjects : RelatedObjects.ListObjects()


### PR DESCRIPTION
When a Report is updated the published `incident.report.amended` has a `whatChanged` field in the `additionalInformation`.

This field is an enum that the consumers of these domain events can use to have a better idea of what part of the report changed, e.g. prisoners involved, staff involved, etc...

If the endpoint to update only the basic information ([`PATCH /incident-reports/{id}`](https://incident-reporting-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/Incident%20reports/updateReport)) was used this field would be set to `BASIC_REPORT` to indicate that only the Report key properties may have changed.

The sync upsert endpoint is a bit special in the sense that the client pass the whole Report's blob.
This means that any part of the Report could change (and potentially different parts at the same time).
In this case the `whatChanged` field would be set to `ANYTHING` to indicate that any part of the report may have changed (this is vague but still less ambiguous than setting the field to `null`)