### PR TITLE
IR-68: Tighten string length validation and in swagger/open-api documentation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddCorrectionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddCorrectionRequest.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.CorrectionReason
 data class AddCorrectionRequest(
   @Schema(description = "Why the correction is needed", required = true)
   val reason: CorrectionReason,
-  @Schema(description = "The changes being requested", required = true)
+  @Schema(description = "The changes being requested", required = true, minLength = 1)
   @field:Size(min = 1)
   val descriptionOfChange: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddEvidence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddEvidence.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 
 @Schema(description = "Add evidence to an incident report")
 data class AddEvidence(
-  @Schema(description = "Type of evidence", required = true)
+  @Schema(description = "Type of evidence", required = true, minLength = 1)
+  @field:Size(min = 1)
   val type: String,
-  @Schema(description = "Description of evidence", required = true)
+  @Schema(description = "Description of evidence", required = true, minLength = 1)
+  @field:Size(min = 1)
   val description: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddLocation.kt
@@ -1,13 +1,17 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 
 @Schema(description = "Add a location to an incident report")
 data class AddLocation(
-  @Schema(description = "NOMIS id of location", required = true)
+  @Schema(description = "NOMIS id of location", required = true, minLength = 1)
+  @field:Size(min = 1)
   val locationId: String,
-  @Schema(description = "Type of location", required = true)
+  @Schema(description = "Type of location", required = true, minLength = 1)
+  @field:Size(min = 1)
   val type: String,
-  @Schema(description = "Description of location", required = true)
+  @Schema(description = "Description of location", required = true, minLength = 1)
+  @field:Size(min = 1)
   val description: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddPrisonerInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddPrisonerInvolvement.kt
@@ -1,12 +1,14 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerOutcome
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerRole
 
 @Schema(description = "Add an involved prisoner to an incident report")
 data class AddPrisonerInvolvement(
-  @Schema(description = "Prisoner’s NOMIS number", required = true)
+  @Schema(description = "Prisoner’s NOMIS number", required = true, minLength = 7, maxLength = 10)
+  @field:Size(min = 7, max = 10)
   val prisonerNumber: String,
   @Schema(description = "Their role", required = true)
   val prisonerRole: PrisonerRole,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
@@ -6,13 +6,13 @@ import jakarta.validation.constraints.Size
 
 @Schema(description = "Payload to add question with responses to an incident report")
 data class AddQuestionWithResponses(
-  @Schema(description = "The question code", required = true)
-  @field:Size(max = 60)
+  @Schema(description = "The question code", required = true, minLength = 1, maxLength = 60)
+  @field:Size(min = 1, max = 60)
   val code: String,
-  @Schema(description = "The question", required = true)
+  @Schema(description = "The question", required = true, minLength = 1)
   @field:Size(min = 1)
   val question: String,
-  @Schema(description = "The responses to this question", required = true)
+  @Schema(description = "The responses to this question", required = true, minLength = 1)
   @field:Valid
   @field:Size(min = 1)
   val responses: List<AddQuestionResponse>,
@@ -21,7 +21,7 @@ data class AddQuestionWithResponses(
 )
 
 data class AddQuestionResponse(
-  @Schema(description = "The response", required = true)
+  @Schema(description = "The response", required = true, minLength = 1)
   @field:Size(min = 1)
   val response: String,
   @Schema(description = "Optional additional information", required = false, defaultValue = "null")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddStaffInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddStaffInvolvement.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 
 @Schema(description = "Add an involved member of staff to an incident report")
 data class AddStaffInvolvement(
-  @Schema(description = "Username", required = true)
+  @Schema(description = "Username", required = true, minLength = 3, maxLength = 120)
   @field:Size(min = 3, max = 120)
   val staffUsername: String,
   @Schema(description = "Their role", required = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
@@ -16,13 +16,13 @@ data class CreateReportRequest(
   val type: Type,
   @Schema(description = "When the incident took place", required = true, example = "2024-04-29T12:34:56.789012")
   val incidentDateAndTime: LocalDateTime,
-  @Schema(description = "The NOMIS id of the prison where incident took place", required = true, example = "MDI")
+  @Schema(description = "The NOMIS id of the prison where incident took place", required = true, example = "MDI", minLength = 2, maxLength = 6)
   @field:Size(min = 2, max = 6)
   val prisonId: String,
-  @Schema(description = "Brief title describing the incident", required = true)
+  @Schema(description = "Brief title describing the incident", required = true, minLength = 5, maxLength = 255)
   @field:Size(min = 5, max = 255)
   val title: String,
-  @Schema(description = "Longer summary of the incident", required = true)
+  @Schema(description = "Longer summary of the incident", required = true, minLength = 1)
   @field:Size(min = 1)
   val description: String,
   @Schema(description = "Whether to link to a new event", required = false, defaultValue = "false")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateCorrectionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateCorrectionRequest.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.CorrectionReason
 data class UpdateCorrectionRequest(
   @Schema(description = "Why the correction is needed", required = false, defaultValue = "null")
   val reason: CorrectionReason? = null,
-  @Schema(description = "The changes being requested", required = false, defaultValue = "null")
+  @Schema(description = "The changes being requested", required = false, defaultValue = "null", minLength = 1)
   @field:Size(min = 1)
   val descriptionOfChange: String? = null,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateEvidence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateEvidence.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 
 @Schema(description = "Update evidence in an incident report")
 data class UpdateEvidence(
-  @Schema(description = "Type of evidence", required = false, defaultValue = "null")
+  @Schema(description = "Type of evidence", required = false, defaultValue = "null", minLength = 1)
+  @field:Size(min = 1)
   val type: String? = null,
-  @Schema(description = "Description of evidence", required = false, defaultValue = "null")
+  @Schema(description = "Description of evidence", required = false, defaultValue = "null", minLength = 1)
+  @field:Size(min = 1)
   val description: String? = null,
 ) {
   val isEmpty: Boolean =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateLocation.kt
@@ -1,14 +1,18 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 
 @Schema(description = "Update a location in an incident report")
 data class UpdateLocation(
-  @Schema(description = "NOMIS id of location", required = false, defaultValue = "null")
+  @Schema(description = "NOMIS id of location", required = false, defaultValue = "null", minLength = 1)
+  @field:Size(min = 1)
   val locationId: String? = null,
-  @Schema(description = "Type of location", required = false, defaultValue = "null")
+  @Schema(description = "Type of location", required = false, defaultValue = "null", minLength = 1)
+  @field:Size(min = 1)
   val type: String? = null,
-  @Schema(description = "Description of location", required = false, defaultValue = "null")
+  @Schema(description = "Description of location", required = false, defaultValue = "null", minLength = 1)
+  @field:Size(min = 1)
   val description: String? = null,
 ) {
   val isEmpty: Boolean =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdatePrisonerInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdatePrisonerInvolvement.kt
@@ -1,13 +1,15 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerOutcome
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerRole
 import java.util.Optional
 
 @Schema(description = "Update an involved prisoner in an incident report")
 data class UpdatePrisonerInvolvement(
-  @Schema(description = "Prisoner’s NOMIS number", required = false, defaultValue = "null")
+  @Schema(description = "Prisoner’s NOMIS number", required = false, defaultValue = "null", minLength = 7, maxLength = 10)
+  @field:Size(min = 7, max = 10)
   val prisonerNumber: String? = null,
   @Schema(description = "Their role", required = false, defaultValue = "null")
   val prisonerRole: PrisonerRole? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateReportRequest.kt
@@ -10,13 +10,13 @@ import java.time.LocalDateTime
 data class UpdateReportRequest(
   @Schema(description = "When the incident took place", required = false, defaultValue = "null", example = "2024-04-29T12:34:56.789012")
   val incidentDateAndTime: LocalDateTime? = null,
-  @Schema(description = "The NOMIS id of the prison where incident took place", required = false, defaultValue = "null", example = "MDI")
+  @Schema(description = "The NOMIS id of the prison where incident took place", required = false, defaultValue = "null", example = "MDI", minLength = 2, maxLength = 6)
   @field:Size(min = 2, max = 6)
   val prisonId: String? = null,
-  @Schema(description = "Brief title describing the incident", required = false, defaultValue = "null")
+  @Schema(description = "Brief title describing the incident", required = false, defaultValue = "null", minLength = 5, maxLength = 255)
   @field:Size(min = 5, max = 255)
   val title: String? = null,
-  @Schema(description = "Longer summary of the incident", required = false, defaultValue = "null")
+  @Schema(description = "Longer summary of the incident", required = false, defaultValue = "null", minLength = 1)
   @field:Size(min = 1)
   val description: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateStaffInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateStaffInvolvement.kt
@@ -7,7 +7,7 @@ import java.util.Optional
 
 @Schema(description = "Update an involved member of staff in an incident report")
 data class UpdateStaffInvolvement(
-  @Schema(description = "Username", required = false, defaultValue = "null")
+  @Schema(description = "Username", required = false, defaultValue = "null", minLength = 3, maxLength = 120)
   @field:Size(min = 3, max = 120)
   val staffUsername: String? = null,
   @Schema(description = "Their role", required = false, defaultValue = "null")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -90,7 +90,7 @@ class ReportResource(
       defaultValue = "null",
       example = "MDI",
       minLength = 2,
-      maxLength = 10,
+      maxLength = 6,
     )
     @RequestParam(required = false)
     @Size(min = 2, max = 6)


### PR DESCRIPTION
NB: Nullable comment-type fields allow empty strings