### PR TITLE
IR-385: Rename the human-visible identifier of events and reports

### DIFF
--- a/docs/0004-modeling-irs.md
+++ b/docs/0004-modeling-irs.md
@@ -29,7 +29,7 @@ classDiagram
         LocalDateTime  createdAt
         String  description
         LocalDateTime  eventDateAndTime
-        String  eventId
+        String  eventReference
         LocalDateTime  modifiedAt
         String  modifiedBy
         String  prisonId
@@ -84,11 +84,11 @@ classDiagram
         LocalDateTime  createdAt
         String  description
         LocalDateTime  incidentDateAndTime
-        String  incidentNumber
         LocalDateTime  modifiedAt
         String  modifiedBy
         String  prisonId
         String  questionSetId
+        String  reportReference
         LocalDateTime  reportedAt
         String  reportedBy
         InformationSource  source
@@ -117,11 +117,11 @@ classDiagram
     }
 
 CorrectionRequest "0..*" <--> "1" Report
-Evidence "0..*" <--> "1" Report
 HistoricalQuestion "0..*" <--> "1" History
 HistoricalResponse "0..*" <--> "1" HistoricalQuestion
 Question "1" <--> "0..*" Response
 Report "1..*" <--> "1" Event
+Report "1" <--> "0..*" Evidence
 Report "1" <--> "0..*" History
 Report "1" <--> "0..*" Location
 Report "1" <--> "0..*" PrisonerInvolvement
@@ -144,7 +144,7 @@ classDiagram
         integer id
     }
     class event {
-        varchar(25) event_id
+        varchar(25) event_reference
         timestamp event_date_and_time
         varchar(255) title
         text description
@@ -209,7 +209,7 @@ classDiagram
     }
     class report {
         integer event_id
-        varchar(25) incident_number
+        varchar(25) report_reference
         varchar(255) title
         text description
         varchar(6) prison_id
@@ -250,16 +250,16 @@ classDiagram
         integer id
     }
 
-correction_request --> report: report_id
-evidence --> report: report_id
-historical_question --> history: history_id
-historical_response --> historical_question: historical_question_id
-history --> report: report_id
-location --> report: report_id
-prisoner_involvement --> report: report_id
-question --> report: report_id
-report --> event: event_id
-response --> question: question_id
-staff_involvement --> report: report_id
-status_history --> report: report_id
+correction_request  -->  report : report_id
+evidence  -->  report : report_id
+historical_question  -->  history : history_id
+historical_response  -->  historical_question : historical_question_id
+history  -->  report : report_id
+location  -->  report : report_id
+prisoner_involvement  -->  report : report_id
+question  -->  report : report_id
+report  -->  event : event_id
+response  -->  question : question_id
+staff_involvement  -->  report : report_id
+status_history  -->  report : report_id
 ```

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/ApplicationInsightsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/ApplicationInsightsConfiguration.kt
@@ -21,7 +21,7 @@ fun TelemetryClient.trackEvent(name: String, properties: Map<String, String>) {
 fun TelemetryClient.trackEvent(name: String, report: ReportBasic, extraProperties: Map<String, String>? = null) {
   val properties = mutableMapOf(
     "id" to report.id.toString(),
-    "incidentNumber" to report.incidentNumber,
+    "reportReference" to report.reportReference,
     "prisonId" to report.prisonId,
   )
   extraProperties?.let { properties.putAll(it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Event.kt
@@ -7,8 +7,8 @@ import java.time.LocalDateTime
 @Schema(description = "Event linking multiple incident reports")
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class Event(
-  @Schema(description = "The human-readable identifier of this report", required = true)
-  val eventId: String,
+  @Schema(description = "The human-readable identifier of this event", required = true)
+  val eventReference: String,
   @Schema(description = "When the incident took place", required = true, example = "2024-04-29T12:34:56.789012")
   val eventDateAndTime: LocalDateTime,
   @Schema(description = "The NOMIS id of the prison where incident took place", required = true, example = "MDI")
@@ -19,10 +19,10 @@ data class Event(
   @Schema(description = "Longer summary of the event", required = true)
   val description: String,
 
-  @Schema(description = "When the report was first created", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the event was first created", required = true, example = "2024-04-29T12:34:56.789012")
   val createdAt: LocalDateTime,
-  @Schema(description = "When the report was last changed", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the event was last changed", required = true, example = "2024-04-29T12:34:56.789012")
   val modifiedAt: LocalDateTime,
-  @Schema(description = "Username of the person who last changed this report", required = true)
+  @Schema(description = "Username of the person who last changed this event", required = true)
   val modifiedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportBasic.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportBasic.kt
@@ -14,7 +14,7 @@ open class ReportBasic(
   @Schema(description = "The internal ID of this report", required = true)
   val id: UUID,
   @Schema(description = "The human-readable identifier of this report", required = true)
-  val incidentNumber: String,
+  val reportReference: String,
   @Schema(description = "Incident report type", required = true)
   val type: Type,
   @Schema(description = "When the incident took place", required = true, example = "2024-04-29T12:34:56.789012")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 @JsonInclude(JsonInclude.Include.ALWAYS)
 class ReportWithDetails(
   id: UUID,
-  incidentNumber: String,
+  reportReference: String,
   type: Type,
   incidentDateAndTime: LocalDateTime,
   prisonId: String,
@@ -48,7 +48,7 @@ class ReportWithDetails(
   val correctionRequests: List<CorrectionRequest>,
 ) : ReportBasic(
   id = id,
-  incidentNumber = incidentNumber,
+  reportReference = reportReference,
   type = type,
   incidentDateAndTime = incidentDateAndTime,
   prisonId = prisonId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 fun NomisReport.toNewEntity(): Report {
   val status = Status.fromNomisCode(status.code)
   val report = Report(
-    incidentNumber = "$incidentId",
+    reportReference = "$incidentId",
     type = Type.fromNomisCode(type),
     incidentDateAndTime = incidentDateTime,
     prisonId = prison.code,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
@@ -30,7 +30,7 @@ fun NomisReport.toNewEntity(): Report {
     source = InformationSource.NOMIS,
     assignedTo = reportingStaff.username,
     event = Event(
-      eventId = "$incidentId",
+      eventReference = "$incidentId",
       eventDateAndTime = incidentDateTime,
       prisonId = prison.code,
       title = title ?: NO_DETAILS_GIVEN,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
@@ -28,11 +28,11 @@ data class CreateReportRequest(
   @Schema(description = "Whether to link to a new event", required = false, defaultValue = "false")
   val createNewEvent: Boolean = false,
   @Schema(description = "Which existing event to link to", required = false, defaultValue = "null")
-  val linkedEventId: String? = null,
+  val linkedEventReference: String? = null,
 ) {
   fun validate(now: LocalDateTime) {
-    if (!createNewEvent && linkedEventId.isNullOrEmpty()) {
-      throw ValidationException("Either createNewEvent or linkedEventId must be provided")
+    if (!createNewEvent && linkedEventReference.isNullOrEmpty()) {
+      throw ValidationException("Either createNewEvent or linkedEventReference must be provided")
     }
     if (!type.active) {
       throw ValidationException("Inactive incident type $type")
@@ -65,9 +65,9 @@ data class CreateReportRequest(
     return report
   }
 
-  fun toNewEvent(generateEventId: String, requestUsername: String, now: LocalDateTime): Event {
+  fun toNewEvent(generatedEventReference: String, requestUsername: String, now: LocalDateTime): Event {
     return Event(
-      eventId = generateEventId,
+      eventReference = generatedEventReference,
       eventDateAndTime = incidentDateAndTime,
       prisonId = prisonId,
       title = title,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
@@ -42,10 +42,10 @@ data class CreateReportRequest(
     }
   }
 
-  fun toNewEntity(incidentNumber: String, event: Event, requestUsername: String, now: LocalDateTime): Report {
+  fun toNewEntity(reportReference: String, event: Event, requestUsername: String, now: LocalDateTime): Report {
     val status = Status.DRAFT
     val report = Report(
-      incidentNumber = incidentNumber,
+      reportReference = reportReference,
       type = type,
       title = title,
       incidentDateAndTime = incidentDateAndTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
@@ -22,7 +22,7 @@ class Event(
 
   /**
    * Human-readable reference.
-   * Matches incident report number when sourced from NOMIS.
+   * Matches incident number when sourced from NOMIS.
    * Prefixed with “IE-” when sourced from DPS.
    */
   @Column(nullable = false, unique = true, length = 25)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
@@ -13,17 +13,20 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.Event as EventDto
 
 @Entity
 class Event(
+  /**
+   * Internal ID which should not be seen by users
+   */
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long? = null,
 
   /**
-   * Human readable ID.
+   * Human-readable reference.
    * Matches incident report number when sourced from NOMIS.
    * Prefixed with “IE-” when sourced from DPS.
    */
   @Column(nullable = false, unique = true, length = 25)
-  val eventId: String,
+  val eventReference: String,
 
   var eventDateAndTime: LocalDateTime,
   var prisonId: String,
@@ -39,7 +42,7 @@ class Event(
   var modifiedBy: String,
 ) {
   override fun toString(): String {
-    return "Event(eventId=$eventId)"
+    return "Event(eventReference=$eventReference)"
   }
 
   fun addReport(report: Report): Report {
@@ -50,7 +53,7 @@ class Event(
   }
 
   fun toDto() = EventDto(
-    eventId = eventId,
+    eventReference = eventReference,
     prisonId = prisonId,
     eventDateAndTime = eventDateAndTime,
     title = title,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -58,18 +58,21 @@ import java.util.UUID
   ],
 )
 class Report(
+  /**
+   * Internal ID which should not be seen by users
+   */
   @Id
   @GeneratedUuidV7
   @Column(name = "id", updatable = false, nullable = false)
   val id: UUID? = null,
 
   /**
-   * Human readable ID.
+   * Human-readable reference. Previously known as ”incident number” in NOMIS.
    * A number when sourced from NOMIS.
    * Prefixed with “IR-” when sourced from DPS.
    */
   @Column(nullable = false, unique = true, length = 25)
-  val incidentNumber: String,
+  val reportReference: String,
 
   var incidentDateAndTime: LocalDateTime,
 
@@ -144,7 +147,7 @@ class Report(
   var modifiedBy: String,
 ) {
   override fun toString(): String {
-    return "Report(incidentNumber=$incidentNumber)"
+    return "Report(reportReference=$reportReference)"
   }
 
   fun getQuestions(): List<Question> = questions
@@ -336,7 +339,7 @@ class Report(
 
   fun toDtoBasic() = ReportBasic(
     id = id!!,
-    incidentNumber = incidentNumber,
+    reportReference = reportReference,
     incidentDateAndTime = incidentDateAndTime,
     prisonId = prisonId,
     type = type,
@@ -354,7 +357,7 @@ class Report(
 
   fun toDtoWithDetails() = ReportWithDetails(
     id = id!!,
-    incidentNumber = incidentNumber,
+    reportReference = reportReference,
     incidentDateAndTime = incidentDateAndTime,
     prisonId = prisonId,
     type = type,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/EventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/EventRepository.kt
@@ -7,10 +7,10 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Event
 
 @Repository
 interface EventRepository : JpaRepository<Event, Long> {
-  fun findOneByEventId(eventId: String): Event?
+  fun findOneByEventReference(eventReference: String): Event?
 
   @Query(value = "SELECT nextval('event_sequence')", nativeQuery = true)
-  fun getNextEventId(): Long
+  fun getNextEventReference(): Long
 }
 
-fun EventRepository.generateEventId() = "IE-%016d".format(getNextEventId())
+fun EventRepository.generateEventReference() = "IE-%016d".format(getNextEventReference())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/ReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/ReportRepository.kt
@@ -13,13 +13,13 @@ interface ReportRepository : JpaRepository<Report, UUID>, JpaSpecificationExecut
   @EntityGraph(value = "Report.eager", type = EntityGraph.EntityGraphType.FETCH)
   fun findOneEagerlyById(id: UUID): Report?
 
-  fun findByIncidentNumber(incidentNumber: String): Report?
+  fun findByReportReference(reportReference: String): Report?
 
   @EntityGraph(value = "Report.eager", type = EntityGraph.EntityGraphType.FETCH)
-  fun findOneEagerlyByIncidentNumber(incidentNumber: String): Report?
+  fun findOneEagerlyByReportReference(reportReference: String): Report?
 
   @Query(value = "SELECT nextval('report_sequence')", nativeQuery = true)
-  fun getNextIncidentNumber(): Long
+  fun getNextReportReference(): Long
 }
 
-fun ReportRepository.generateIncidentNumber() = "IR-%016d".format(getNextIncidentNumber())
+fun ReportRepository.generateReportReference() = "IR-%016d".format(getNextReportReference())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventBaseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventBaseResource.kt
@@ -24,7 +24,7 @@ abstract class EventBaseResource {
         eventType = event,
         additionalInformation = AdditionalInformation(
           id = report.id,
-          incidentNumber = report.incidentNumber,
+          reportReference = report.reportReference,
           source = informationSource,
           whatChanged = whatChanged,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportRelatedObjectsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportRelatedObjectsResource.kt
@@ -58,7 +58,7 @@ abstract class ReportRelatedObjectsResource<ResponseDto, AddRequest, UpdateReque
         basicReport
       }
 
-      log.info("$changeMessage number=${report.incidentNumber} ID=${report.id}")
+      log.info("$changeMessage reference=${report.reportReference} ID=${report.id}")
       telemetryClient.trackEvent(
         // TODO: should different related object actions raise different events?
         changeMessage,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -257,11 +257,11 @@ class ReportResource(
       ?: throw ReportNotFoundException(id)
   }
 
-  @GetMapping("/incident-number/{incidentNumber}")
+  @GetMapping("/reference/{reportReference}")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
   @Operation(
-    summary = "Returns the incident report (with only basic information) for this incident number",
+    summary = "Returns the incident report (with only basic information) for this reference",
     description = "Requires role VIEW_INCIDENT_REPORTS",
     responses = [
       ApiResponse(
@@ -285,20 +285,20 @@ class ReportResource(
       ),
     ],
   )
-  fun getBasicReportByIncidentNumber(
-    @Schema(description = "The incident report number", example = "2342341242", required = true)
+  fun getBasicReportByReference(
+    @Schema(description = "The incident report reference", example = "2342341242", required = true)
     @PathVariable
-    incidentNumber: String,
+    reportReference: String,
   ): ReportBasic {
-    return reportService.getBasicReportByIncidentNumber(incidentNumber)
-      ?: throw ReportNotFoundException(incidentNumber)
+    return reportService.getBasicReportByReference(reportReference)
+      ?: throw ReportNotFoundException(reportReference)
   }
 
-  @GetMapping("/incident-number/{incidentNumber}/with-details")
+  @GetMapping("/reference/{reportReference}/with-details")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_VIEW_INCIDENT_REPORTS')")
   @Operation(
-    summary = "Returns the incident report (with all related details) for this incident number",
+    summary = "Returns the incident report (with all related details) for this reference",
     description = "Requires role VIEW_INCIDENT_REPORTS",
     responses = [
       ApiResponse(
@@ -322,13 +322,13 @@ class ReportResource(
       ),
     ],
   )
-  fun getReportWithDetailsByIncidentNumber(
-    @Schema(description = "The incident report number", example = "2342341242", required = true)
+  fun getReportWithDetailsByReference(
+    @Schema(description = "The incident report reference", example = "2342341242", required = true)
     @PathVariable
-    incidentNumber: String,
+    reportReference: String,
   ): ReportWithDetails {
-    return reportService.getReportWithDetailsByIncidentNumber(incidentNumber)
-      ?: throw ReportNotFoundException(incidentNumber)
+    return reportService.getReportWithDetailsByReference(reportReference)
+      ?: throw ReportNotFoundException(reportReference)
   }
 
   @PostMapping("")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncService.kt
@@ -64,7 +64,7 @@ class NomisSyncService(
       val constraintViolation = e.cause as? org.hibernate.exception.ConstraintViolationException
       if (
         constraintViolation != null &&
-        listOf("event_id", "incident_number").contains(constraintViolation.constraintName)
+        listOf("event_reference", "incident_number").contains(constraintViolation.constraintName)
       ) {
         throw ReportAlreadyExistsException("${incidentReport.incidentId}")
       } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncService.kt
@@ -64,7 +64,7 @@ class NomisSyncService(
       val constraintViolation = e.cause as? org.hibernate.exception.ConstraintViolationException
       if (
         constraintViolation != null &&
-        listOf("event_reference", "incident_number").contains(constraintViolation.constraintName)
+        listOf("event_reference", "report_reference").contains(constraintViolation.constraintName)
       ) {
         throw ReportAlreadyExistsException("${incidentReport.incidentId}")
       } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -28,7 +28,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.utils.MaybeChanged
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateEventReference
-import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateIncidentNumber
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateReportReference
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateFrom
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateUntil
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByPrisonId
@@ -92,8 +92,8 @@ class ReportService(
       ?.toDtoBasic()
   }
 
-  fun getBasicReportByIncidentNumber(incidentNumber: String): ReportBasic? {
-    return reportRepository.findByIncidentNumber(incidentNumber)
+  fun getBasicReportByReference(reportReference: String): ReportBasic? {
+    return reportRepository.findByReportReference(reportReference)
       ?.toDtoBasic()
   }
 
@@ -102,8 +102,8 @@ class ReportService(
       ?.toDtoWithDetails()
   }
 
-  fun getReportWithDetailsByIncidentNumber(incidentNumber: String): ReportWithDetails? {
-    return reportRepository.findOneEagerlyByIncidentNumber(incidentNumber)
+  fun getReportWithDetailsByReference(reportReference: String): ReportWithDetails? {
+    return reportRepository.findOneEagerlyByReportReference(reportReference)
       ?.toDtoWithDetails()
   }
 
@@ -119,7 +119,7 @@ class ReportService(
         report.event.reports.removeIf { it.id == id }
         reportRepository.deleteById(id)
 
-        log.info("Deleted incident report number=${report.incidentNumber} ID=${report.id}")
+        log.info("Deleted incident report reference=${report.reportReference} ID=${report.id}")
         telemetryClient.trackEvent(
           "Deleted incident report",
           it,
@@ -153,7 +153,7 @@ class ReportService(
     }
 
     val newReport = createReportRequest.toNewEntity(
-      incidentNumber = reportRepository.generateIncidentNumber(),
+      reportReference = reportRepository.generateReportReference(),
       event = event,
       requestUsername = requestUsername,
       now = now,
@@ -161,7 +161,7 @@ class ReportService(
 
     val report = reportRepository.save(newReport).toDtoWithDetails()
 
-    log.info("Created draft incident report number=${report.incidentNumber} ID=${report.id}")
+    log.info("Created draft incident report reference=${report.reportReference} ID=${report.id}")
     telemetryClient.trackEvent(
       "Created draft incident report",
       report,
@@ -188,7 +188,7 @@ class ReportService(
         } else {
           "Updated incident report"
         }
-        log.info("$changeMessage number=$incidentNumber ID=$id")
+        log.info("$changeMessage reference=$reportReference ID=$id")
         telemetryClient.trackEvent(
           changeMessage,
           this,
@@ -219,7 +219,7 @@ class ReportService(
       }
 
       maybeChangedReport.alsoIfChanged { reportWithDetails ->
-        log.info("Changed incident report status to ${changeStatusRequest.newStatus} for number=${reportWithDetails.incidentNumber} ID=$id")
+        log.info("Changed incident report status to ${changeStatusRequest.newStatus} for reference=${reportWithDetails.reportReference} ID=$id")
         telemetryClient.trackEvent(
           "Changed incident report status",
           reportWithDetails,
@@ -250,7 +250,7 @@ class ReportService(
       }
 
       maybeChangedReport.alsoIfChanged { reportWithDetails ->
-        log.info("Changed incident report type to ${changeTypeRequest.newType} for number=${reportWithDetails.incidentNumber} ID=$id")
+        log.info("Changed incident report type to ${changeTypeRequest.newType} for reference=${reportWithDetails.reportReference} ID=$id")
         telemetryClient.trackEvent(
           "Changed incident report type",
           reportWithDetails,
@@ -293,7 +293,7 @@ class ReportService(
 
       val reportBasic = toDtoBasic()
 
-      log.info("Added question with ${addRequest.responses.size} responses to report number=$incidentNumber ID=$id")
+      log.info("Added question with ${addRequest.responses.size} responses to report reference=$reportReference ID=$id")
       telemetryClient.trackEvent(
         "Added question with ${addRequest.responses.size} responses",
         reportBasic,
@@ -314,7 +314,7 @@ class ReportService(
 
       val reportBasic = toDtoBasic()
 
-      log.info("Deleted last question and responses from report number=$incidentNumber ID=$id")
+      log.info("Deleted last question and responses from report reference=$reportReference ID=$id")
       telemetryClient.trackEvent(
         "Deleted last question and responses",
         reportBasic,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.UpdateReportRe
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.utils.MaybeChanged
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
-import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateEventId
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateEventReference
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateIncidentNumber
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateFrom
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateUntil
@@ -141,12 +141,12 @@ class ReportService(
 
     createReportRequest.validate(now = now)
 
-    val event = if (createReportRequest.linkedEventId != null) {
-      eventRepository.findOneByEventId(createReportRequest.linkedEventId)
-        ?: throw EventNotFoundException(createReportRequest.linkedEventId)
+    val event = if (createReportRequest.linkedEventReference != null) {
+      eventRepository.findOneByEventReference(createReportRequest.linkedEventReference)
+        ?: throw EventNotFoundException(createReportRequest.linkedEventReference)
     } else {
       createReportRequest.toNewEvent(
-        eventRepository.generateEventId(),
+        eventRepository.generateEventReference(),
         requestUsername = requestUsername,
         now = now,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/SnsService.kt
@@ -92,8 +92,10 @@ enum class WhatChanged {
 }
 
 data class AdditionalInformation(
+  /** Internal ID */
   val id: UUID,
-  val incidentNumber: String,
+  /** Human-readable reference */
+  val reportReference: String,
   val source: InformationSource,
   val whatChanged: WhatChanged? = null,
 )

--- a/src/main/resources/db/migration/V1_1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1_1__initial_schema.sql
@@ -2,8 +2,8 @@ create table event
 (
     id                  serial
         constraint event_pk primary key,
-    event_id            varchar(25)                         not null
-        constraint event_id unique,
+    event_reference     varchar(25)                         not null
+        constraint event_reference unique,
     event_date_and_time timestamp                           not null,
 
     title               varchar(255)                        not null,
@@ -17,7 +17,7 @@ create table event
 
 create sequence event_sequence
     start with 1000000
-    owned by event.event_id;
+    owned by event.event_reference;
 
 create index event_event_date_and_time_idx on event (event_date_and_time);
 create index event_created_at_idx on event (created_at);

--- a/src/main/resources/db/migration/V1_1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1_1__initial_schema.sql
@@ -28,8 +28,8 @@ create table report
         constraint report_pk primary key,
     event_id               integer                              not null
         constraint report_event_fk references event (id) on delete restrict,
-    incident_number        varchar(25)                          not null
-        constraint incident_number unique,
+    report_reference       varchar(25)                          not null
+        constraint report_reference unique,
 
     title                  varchar(255)                         not null,
     description            text                                 not null,
@@ -52,7 +52,7 @@ create table report
 
 create sequence report_sequence
     start with 1000000
-    owned by report.incident_number;
+    owned by report.report_reference;
 
 create index report_incident_date_and_time_idx on report (incident_date_and_time);
 create index report_reported_at_idx on report (reported_at);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/EntityToDtoMappingEdgeCaseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/EntityToDtoMappingEdgeCaseTest.kt
@@ -37,7 +37,7 @@ class EntityToDtoMappingEdgeCaseTest : SqsIntegrationTestBase() {
   @Test
   fun `report must have a non-null id to map to the dto`() {
     val unsavedReport = buildIncidentReport(
-      incidentNumber = "1234",
+      reportReference = "1234",
       reportTime = now,
     )
     assertThat(unsavedReport.id).isNull()
@@ -56,7 +56,7 @@ class EntityToDtoMappingEdgeCaseTest : SqsIntegrationTestBase() {
   fun `report dto reflects whether the entity's source was NOMIS`() {
     val reportFromNomis = reportRepository.save(
       buildIncidentReport(
-        incidentNumber = "1234",
+        reportReference = "1234",
         reportTime = now,
         source = InformationSource.NOMIS,
       ),
@@ -66,7 +66,7 @@ class EntityToDtoMappingEdgeCaseTest : SqsIntegrationTestBase() {
 
     val reportFromDps = reportRepository.save(
       buildIncidentReport(
-        incidentNumber = "1235",
+        reportReference = "1235",
         reportTime = now,
         source = InformationSource.DPS,
       ),
@@ -84,7 +84,7 @@ class EntityToDtoMappingEdgeCaseTest : SqsIntegrationTestBase() {
     fun setUp() {
       report = reportRepository.save(
         buildIncidentReport(
-          incidentNumber = "IR-0000000001124143",
+          reportReference = "IR-0000000001124143",
           reportTime = now,
           source = InformationSource.DPS,
           generateStaffInvolvement = 2,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
@@ -72,7 +72,7 @@ class NomisDtoToJpaMappingEdgeCaseTest {
       val eventEntity = reportEntity.event
       assertThat(eventEntity.title).isEqualTo("TITLE")
       assertThat(eventEntity.description).isEqualTo("DESCRIPTION")
-      assertThat(eventEntity.eventId).isEqualTo("112414323")
+      assertThat(eventEntity.eventReference).isEqualTo("112414323")
       assertThat(eventEntity.prisonId).isEqualTo("MDI")
       assertThat(eventEntity.modifiedBy).isEqualTo("user1")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/NomisDtoToJpaMappingEdgeCaseTest.kt
@@ -53,7 +53,7 @@ class NomisDtoToJpaMappingEdgeCaseTest {
       val reportEntity = reportDto.toNewEntity()
       assertThat(reportEntity.title).isEqualTo("TITLE")
       assertThat(reportEntity.description).isEqualTo("DESCRIPTION")
-      assertThat(reportEntity.incidentNumber).isEqualTo("112414323")
+      assertThat(reportEntity.reportReference).isEqualTo("112414323")
       assertThat(reportEntity.prisonId).isEqualTo("MDI")
       assertThat(reportEntity.questionSetId).isEqualTo("2124")
       assertThat(reportEntity.assignedTo).isEqualTo("user1")
@@ -111,7 +111,7 @@ class NomisDtoToJpaMappingEdgeCaseTest {
 
     /** existing report created in NOMIS yesterday by a different user */
     private fun buildExistingReport() = buildIncidentReport(
-      incidentNumber = "112414323",
+      reportReference = "112414323",
       reportingUsername = "old-user",
       reportTime = yesterday,
       source = InformationSource.NOMIS,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/IncidentReportBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/IncidentReportBuilder.kt
@@ -46,7 +46,7 @@ fun buildIncidentReport(
     assignedTo = reportingUsername,
     modifiedBy = reportingUsername,
     event = Event(
-      eventId = when (source) {
+      eventReference = when (source) {
         InformationSource.DPS -> "IE-${incidentNumber.removePrefix("IR-")}"
         InformationSource.NOMIS -> incidentNumber
       },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/IncidentReportBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/IncidentReportBuilder.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 import java.time.LocalDateTime
 
 fun buildIncidentReport(
-  incidentNumber: String,
+  reportReference: String,
   reportTime: LocalDateTime,
   prisonId: String = "MDI",
   source: InformationSource = InformationSource.DPS,
@@ -31,13 +31,13 @@ fun buildIncidentReport(
 ): Report {
   val eventDateAndTime = reportTime.minusHours(1)
   val report = Report(
-    incidentNumber = incidentNumber,
+    reportReference = reportReference,
     incidentDateAndTime = eventDateAndTime,
     prisonId = prisonId,
     source = source,
     status = status,
     type = type,
-    title = "Incident Report $incidentNumber",
+    title = "Incident Report $reportReference",
     description = "A new incident created in the new service of type ${type.description}",
     reportedAt = reportTime,
     createdAt = reportTime,
@@ -47,8 +47,8 @@ fun buildIncidentReport(
     modifiedBy = reportingUsername,
     event = Event(
       eventReference = when (source) {
-        InformationSource.DPS -> "IE-${incidentNumber.removePrefix("IR-")}"
-        InformationSource.NOMIS -> incidentNumber
+        InformationSource.DPS -> "IE-${reportReference.removePrefix("IR-")}"
+        InformationSource.NOMIS -> reportReference
       },
       eventDateAndTime = eventDateAndTime,
       prisonId = prisonId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/SqsIntegrationTestBase.kt
@@ -93,15 +93,15 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
 
   fun assertThatDomainEventWasSent(
     eventType: String,
-    incidentNumber: String?,
+    reportReference: String?,
     source: InformationSource = InformationSource.DPS,
     whatChanged: WhatChanged? = null,
   ) {
     getDomainEvents(1).let {
       val event = it[0]
       assertThat(event.eventType).isEqualTo(eventType)
-      incidentNumber?.let {
-        assertThat(event.additionalInformation?.incidentNumber).isEqualTo(incidentNumber)
+      reportReference?.let {
+        assertThat(event.additionalInformation?.reportReference).isEqualTo(reportReference)
       }
       assertThat(event.additionalInformation?.source).isEqualTo(source)
       assertThat(event.additionalInformation?.whatChanged).isEqualTo(whatChanged)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.integration.IntegrationTes
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateEventReference
-import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateIncidentNumber
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateReportReference
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateFrom
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateUntil
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByPrisonId
@@ -67,7 +67,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
     fun `can filter reports by simple property specification`() {
       val report = reportRepository.save(
         buildIncidentReport(
-          incidentNumber = "12345",
+          reportReference = "12345",
           reportTime = now.minusDays(1),
         ),
       )
@@ -115,7 +115,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
     fun `can filter reports by a combination of specifications`() {
       val report1Id = reportRepository.save(
         buildIncidentReport(
-          incidentNumber = "12345",
+          reportReference = "12345",
           reportTime = now.minusDays(3),
           prisonId = "MDI",
           source = InformationSource.DPS,
@@ -125,7 +125,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
       ).id!!
       val report2Id = reportRepository.save(
         buildIncidentReport(
-          incidentNumber = "12346",
+          reportReference = "12346",
           reportTime = now.minusDays(2),
           prisonId = "LEI",
           source = InformationSource.DPS,
@@ -135,7 +135,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
       ).id!!
       val report3Id = reportRepository.save(
         buildIncidentReport(
-          incidentNumber = "IR-0000000001124143",
+          reportReference = "IR-0000000001124143",
           reportTime = now.minusDays(1),
           prisonId = "MDI",
           source = InformationSource.NOMIS,
@@ -219,7 +219,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
     var report =
       reportRepository.save(
         Report(
-          incidentNumber = reportRepository.generateIncidentNumber(),
+          reportReference = reportRepository.generateReportReference(),
           incidentDateAndTime = hourAgo,
           status = Status.AWAITING_ANALYSIS,
           type = Type.SELF_HARM,
@@ -254,7 +254,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
     TestTransaction.end()
     TestTransaction.start()
 
-    report = reportRepository.findOneEagerlyByIncidentNumber(report.incidentNumber)
+    report = reportRepository.findOneEagerlyByReportReference(report.reportReference)
       ?: throw EntityNotFoundException()
 
     report.addQuestion("WHERE_OCCURRED", "Where did this occur?")
@@ -284,7 +284,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
     TestTransaction.end()
     TestTransaction.start()
 
-    report = reportRepository.findOneEagerlyByIncidentNumber(report.incidentNumber)
+    report = reportRepository.findOneEagerlyByReportReference(report.reportReference)
       ?: throw EntityNotFoundException()
     report.changeType(Type.ASSAULT, now, "user5")
 
@@ -298,7 +298,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
     TestTransaction.end()
     TestTransaction.start()
 
-    report = reportRepository.findOneEagerlyByIncidentNumber(report.incidentNumber)
+    report = reportRepository.findOneEagerlyByReportReference(report.reportReference)
       ?: throw EntityNotFoundException()
     assertThat(report.status).isEqualTo(Status.AWAITING_ANALYSIS)
     assertThat(report.type).isEqualTo(Type.ASSAULT)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.helper.buildIncidentReport
 import uk.gov.justice.digital.hmpps.incidentreporting.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventRepository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
-import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateEventId
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateEventReference
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.generateIncidentNumber
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateFrom
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByIncidentDateUntil
@@ -228,7 +228,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
           reportedBy = "user1",
           prisonId = "MDI",
           event = Event(
-            eventId = eventRepository.generateEventId(),
+            eventReference = eventRepository.generateEventReference(),
             eventDateAndTime = hourAgo,
             prisonId = "MDI",
             title = "Event summary",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -400,7 +400,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "title": "An incident occurred updated",
                 "description": "A New Incident From NOMIS",
                 "event": {
-                  "eventId": "112414666",
+                  "eventReference": "112414666",
                   "eventDateAndTime": "2023-12-05T11:34:56",
                   "prisonId": "MDI",
                   "title": "An incident occurred updated",
@@ -658,7 +658,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "title": "An incident occurred updated",
                 "description": "New NOMIS incident",
                 "event": {
-                  "eventId": "$newIncidentId",
+                  "eventReference": "$newIncidentId",
                   "eventDateAndTime": "2023-12-05T11:34:56",
                   "prisonId": "MDI",
                   "title": "An incident occurred updated",
@@ -1122,7 +1122,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "title": "Updated title",
                 "description": "Updated details",
                 "event": {
-                  "eventId": "$INCIDENT_NUMBER",
+                  "eventReference": "$INCIDENT_NUMBER",
                   "eventDateAndTime": "2023-11-25T12:34:56",
                   "prisonId": "FBI",
                   "title": "Updated title",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -39,7 +39,8 @@ import java.time.Clock
 import java.time.LocalDate
 import java.util.UUID
 
-private const val INCIDENT_NUMBER: Long = 112414323
+/** NOMIS incident number maps to a report’s reference */
+private const val NOMIS_INCIDENT_NUMBER: Long = 112414323
 
 @DisplayName("NOMIS sync resource")
 @Transactional
@@ -71,7 +72,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
 
     existingNomisReport = reportRepository.save(
       buildIncidentReport(
-        incidentNumber = "$INCIDENT_NUMBER",
+        reportReference = "$NOMIS_INCIDENT_NUMBER",
         reportTime = now,
         source = InformationSource.NOMIS,
       ),
@@ -85,7 +86,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
     val syncRequest = NomisSyncRequest(
       initialMigration = false,
       incidentReport = NomisReport(
-        incidentId = INCIDENT_NUMBER,
+        incidentId = NOMIS_INCIDENT_NUMBER,
         title = "An incident occurred updated",
         description = "More details about the incident",
         prison = NomisCode("MDI", "Moorland"),
@@ -393,7 +394,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               // language=json
               """
               {
-                "incidentNumber": "112414666",
+                "reportReference": "112414666",
                 "type": "SELF_HARM",
                 "incidentDateAndTime": "2023-12-05T11:34:56",
                 "prisonId": "MDI",
@@ -628,7 +629,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
 
       @Test
       fun `can sync a new incident report after migration created in NOMIS`() {
-        val newIncidentId = INCIDENT_NUMBER + 1
+        val newIncidentId = NOMIS_INCIDENT_NUMBER + 1
         val newIncident = syncRequest.copy(
           initialMigration = false,
           incidentReport = syncRequest.incidentReport.copy(
@@ -651,7 +652,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               // language=json
               """
               {
-                "incidentNumber": "$newIncidentId",
+                "reportReference": "$newIncidentId",
                 "type": "ASSAULT",
                 "incidentDateAndTime": "2023-12-05T11:34:56",
                 "prisonId": "MDI",
@@ -890,7 +891,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
           initialMigration = false,
           id = existingNomisReport.id,
           incidentReport = syncRequest.incidentReport.copy(
-            incidentId = INCIDENT_NUMBER,
+            incidentId = NOMIS_INCIDENT_NUMBER,
             title = "Updated title",
             description = "Updated details",
             reportingStaff = NomisStaff("OF42", 42, "Oscar", "Foxtrot"),
@@ -1115,14 +1116,14 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               """
               {
                 "id": "${existingNomisReport.id}",
-                "incidentNumber": "$INCIDENT_NUMBER",
+                "reportReference": "$NOMIS_INCIDENT_NUMBER",
                 "type": "ASSAULT",
                 "incidentDateAndTime": "2023-11-25T12:34:56",
                 "prisonId": "FBI",
                 "title": "Updated title",
                 "description": "Updated details",
                 "event": {
-                  "eventReference": "$INCIDENT_NUMBER",
+                  "eventReference": "$NOMIS_INCIDENT_NUMBER",
                   "eventDateAndTime": "2023-11-25T12:34:56",
                   "prisonId": "FBI",
                   "title": "Updated title",
@@ -1346,7 +1347,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
 
         assertThatDomainEventWasSent(
           "incident.report.amended",
-          "$INCIDENT_NUMBER",
+          "$NOMIS_INCIDENT_NUMBER",
           InformationSource.NOMIS,
           WhatChanged.ANYTHING,
         )
@@ -1400,7 +1401,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
 
     @Test
     fun `can create a report during initial migration`() {
-      deleteAllReports() // drop reports from test setup to prevent incident number and event id clashes
+      deleteAllReports() // drop reports from test setup to prevent report and event reference clashes
 
       sendAuthorisedSyncRequest(
         initialMigration = true,
@@ -1416,7 +1417,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
 
     @Test
     fun `can create a report after initial migration`() {
-      deleteAllReports() // drop reports from test setup to prevent incident number and event id clashes
+      deleteAllReports() // drop reports from test setup to prevent report and event reference clashes
 
       sendAuthorisedSyncRequest(
         initialMigration = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -538,7 +538,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "title": "Incident Report IR-0000000001124143",
               "description": "A new incident created in the new service of type Finds",
               "event": {
-                "eventId": "IE-0000000001124143",
+                "eventReference": "IE-0000000001124143",
                 "eventDateAndTime": "2023-12-05T11:34:56",
                 "prisonId": "MDI",
                 "title": "An event occurred",
@@ -704,7 +704,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "title": "Incident Report IR-0000000001124143",
               "description": "A new incident created in the new service of type Finds",
               "event": {
-                "eventId": "IE-0000000001124143",
+                "eventReference": "IE-0000000001124143",
                 "eventDateAndTime": "2023-12-05T11:34:56",
                 "prisonId": "MDI",
                 "title": "An event occurred",
@@ -835,7 +835,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           .exchange()
           .expectStatus().isBadRequest
           .expectBody().jsonPath("developerMessage").value<String> {
-            assertThat(it).contains("Either createNewEvent or linkedEventId must be provided")
+            assertThat(it).contains("Either createNewEvent or linkedEventReference must be provided")
           }
 
         assertThatNoDomainEventsWereSent()
@@ -924,7 +924,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           .bodyValue(
             createReportRequest.copy(
               createNewEvent = false,
-              linkedEventId = existingReport.event.eventId,
+              linkedEventReference = existingReport.event.eventReference,
             ).toJson(),
           )
           .exchange()
@@ -939,7 +939,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "title": "An incident occurred",
               "description": "Longer explanation of incident",
               "event": {
-                "eventId": "${existingReport.event.eventId}",
+                "eventReference": "${existingReport.event.eventReference}",
                 "eventDateAndTime": "2023-12-05T11:34:56",
                 "prisonId": "MDI",
                 "title": "An event occurred",
@@ -1241,14 +1241,14 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           .exchange()
           .expectStatus().isOk
 
-        val eventJson = eventRepository.findOneByEventId("IE-0000000001124143")!!
+        val eventJson = eventRepository.findOneByEventReference("IE-0000000001124143")!!
           .toDto().toJson()
         JsonExpectationsHelper().assertJsonEqual(
           if (updateEvent) {
             // language=json
             """
             {
-              "eventId": "IE-0000000001124143",
+              "eventReference": "IE-0000000001124143",
               "eventDateAndTime": "2023-12-05T10:34:56",
               "prisonId": "LEI",
               "title": "Updated report IR-0000000001124143",
@@ -1262,7 +1262,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             // language=json
             """
             {
-              "eventId": "IE-0000000001124143",
+              "eventReference": "IE-0000000001124143",
               "eventDateAndTime": "2023-12-05T11:34:56",
               "prisonId": "MDI",
               "title": "An event occurred",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -71,7 +71,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
     existingReport = reportRepository.save(
       buildIncidentReport(
-        incidentNumber = "IR-0000000001124143",
+        reportReference = "IR-0000000001124143",
         reportTime = now,
       ),
     )
@@ -186,7 +186,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """{
               "content": [{
                 "id": "${existingReport.id}",
-                "incidentNumber": "IR-0000000001124143",
+                "reportReference": "IR-0000000001124143",
                 "incidentDateAndTime": "2023-12-05T11:34:56"
               }],
               "number": 0,
@@ -208,11 +208,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           // makes an additional 4 older reports, 2 of which are from NOMIS
           reportRepository.saveAll(
             listOf("IR-0000000001017203", "IR-0000000001006603", "94728", "31934")
-              .mapIndexed { index, incidentNumber ->
-                val fromDps = incidentNumber.startsWith("IR-")
+              .mapIndexed { index, reportReference ->
+                val fromDps = reportReference.startsWith("IR-")
                 val daysBefore = index.toLong() + 1
                 buildIncidentReport(
-                  incidentNumber = incidentNumber,
+                  reportReference = reportReference,
                   reportTime = now.minusDays(daysBefore),
                   prisonId = if (index < 2) "LEI" else "MDI",
                   status = if (fromDps) Status.DRAFT else Status.AWAITING_ANALYSIS,
@@ -235,23 +235,23 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               """{
                 "content": [
                   {
-                    "incidentNumber": "IR-0000000001124143",
+                    "reportReference": "IR-0000000001124143",
                     "incidentDateAndTime": "2023-12-05T11:34:56"
                   },
                   {
-                    "incidentNumber": "IR-0000000001017203",
+                    "reportReference": "IR-0000000001017203",
                     "incidentDateAndTime": "2023-12-04T11:34:56"
                   },
                   {
-                    "incidentNumber": "IR-0000000001006603",
+                    "reportReference": "IR-0000000001006603",
                     "incidentDateAndTime": "2023-12-03T11:34:56"
                   },
                   {
-                    "incidentNumber": "94728",
+                    "reportReference": "94728",
                     "incidentDateAndTime": "2023-12-02T11:34:56"
                   },
                   {
-                    "incidentNumber": "31934",
+                    "reportReference": "31934",
                     "incidentDateAndTime": "2023-12-01T11:34:56"
                   }
                 ],
@@ -278,11 +278,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               """{
                 "content": [
                   {
-                    "incidentNumber": "IR-0000000001124143",
+                    "reportReference": "IR-0000000001124143",
                     "incidentDateAndTime": "2023-12-05T11:34:56"
                   },
                   {
-                    "incidentNumber": "IR-0000000001017203",
+                    "reportReference": "IR-0000000001017203",
                     "incidentDateAndTime": "2023-12-04T11:34:56"
                   }
                 ],
@@ -309,11 +309,11 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               """{
                 "content": [
                   {
-                    "incidentNumber": "IR-0000000001006603",
+                    "reportReference": "IR-0000000001006603",
                     "incidentDateAndTime": "2023-12-03T11:34:56"
                   },
                   {
-                    "incidentNumber": "94728",
+                    "reportReference": "94728",
                     "incidentDateAndTime": "2023-12-02T11:34:56"
                   }
                 ],
@@ -333,18 +333,18 @@ class ReportResourceTest : SqsIntegrationTestBase() {
           strings = [
             "incidentDateAndTime,ASC",
             "incidentDateAndTime,DESC",
-            "incidentNumber,ASC",
-            "incidentNumber,DESC",
+            "reportReference,ASC",
+            "reportReference,DESC",
             "id,ASC",
             "id,DESC",
           ],
         )
         fun `can sort reports`(sortParam: String) {
-          val expectedIncidentNumbers = mapOf(
+          val expectedReportReferences = mapOf(
             "incidentDateAndTime,ASC" to listOf("31934", "94728", "IR-0000000001006603", "IR-0000000001017203", "IR-0000000001124143"),
             "incidentDateAndTime,DESC" to listOf("IR-0000000001124143", "IR-0000000001017203", "IR-0000000001006603", "94728", "31934"),
-            "incidentNumber,ASC" to listOf("31934", "94728", "IR-0000000001006603", "IR-0000000001017203", "IR-0000000001124143"),
-            "incidentNumber,DESC" to listOf("IR-0000000001124143", "IR-0000000001017203", "IR-0000000001006603", "94728", "31934"),
+            "reportReference,ASC" to listOf("31934", "94728", "IR-0000000001006603", "IR-0000000001017203", "IR-0000000001124143"),
+            "reportReference,DESC" to listOf("IR-0000000001124143", "IR-0000000001017203", "IR-0000000001006603", "94728", "31934"),
             // id, being a UUIDv7, should follow table insertion order (i.e. what setUp methods do above)
             "id,ASC" to listOf("IR-0000000001124143", "IR-0000000001017203", "IR-0000000001006603", "94728", "31934"),
             "id,DESC" to listOf("31934", "94728", "IR-0000000001006603", "IR-0000000001017203", "IR-0000000001124143"),
@@ -366,8 +366,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                 "sort": ["$sortParam"]
               }""",
               false,
-            ).jsonPath("content[*].incidentNumber").value<List<String>> {
-              assertThat(it).isEqualTo(expectedIncidentNumbers)
+            ).jsonPath("content[*].reportReference").value<List<String>> {
+              assertThat(it).isEqualTo(expectedReportReferences)
             }
         }
 
@@ -460,7 +460,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "${existingReport.id}",
-              "incidentNumber": "IR-0000000001124143",
+              "reportReference": "IR-0000000001124143",
               "type": "FINDS",
               "incidentDateAndTime": "2023-12-05T11:34:56",
               "prisonId": "MDI",
@@ -531,7 +531,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "${existingReport.id}",
-              "incidentNumber": "IR-0000000001124143",
+              "reportReference": "IR-0000000001124143",
               "type": "FINDS",
               "incidentDateAndTime": "2023-12-05T11:34:56",
               "prisonId": "MDI",
@@ -577,14 +577,14 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
   }
 
-  @DisplayName("GET /incident-reports/incident-number/{incident-number}")
+  @DisplayName("GET /incident-reports/reference/{reference}")
   @Nested
-  inner class GetBasicReportByIncidentNumber {
+  inner class GetBasicReportByReference {
     private lateinit var url: String
 
     @BeforeEach
     fun setUp() {
-      url = "/incident-reports/incident-number/${existingReport.incidentNumber}"
+      url = "/incident-reports/reference/${existingReport.reportReference}"
     }
 
     @DisplayName("is secured")
@@ -602,8 +602,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     @Nested
     inner class Validation {
       @Test
-      fun `cannot get a report by incident number if it is not found`() {
-        webTestClient.get().uri("/incident-reports/incident-number/IR-11111111")
+      fun `cannot get a report by reference if it is not found`() {
+        webTestClient.get().uri("/incident-reports/reference/IR-11111111")
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
           .header("Content-Type", "application/json")
           .exchange()
@@ -615,7 +615,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     @Nested
     inner class HappyPath {
       @Test
-      fun `can get a report by incident number`() {
+      fun `can get a report by reference`() {
         webTestClient.get().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
           .header("Content-Type", "application/json")
@@ -626,7 +626,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "${existingReport.id}",
-              "incidentNumber": "IR-0000000001124143",
+              "reportReference": "IR-0000000001124143",
               "type": "FINDS",
               "incidentDateAndTime": "2023-12-05T11:34:56",
               "prisonId": "MDI",
@@ -648,14 +648,14 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     }
   }
 
-  @DisplayName("GET /incident-reports/incident-number/{incident-number}/with-details")
+  @DisplayName("GET /incident-reports/reference/{reference}/with-details")
   @Nested
-  inner class GetReportWithDetailsByIncidentNumber {
+  inner class GetReportWithDetailsByReference {
     private lateinit var url: String
 
     @BeforeEach
     fun setUp() {
-      url = "/incident-reports/incident-number/${existingReport.incidentNumber}/with-details"
+      url = "/incident-reports/reference/${existingReport.reportReference}/with-details"
     }
 
     @DisplayName("is secured")
@@ -673,8 +673,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     @Nested
     inner class Validation {
       @Test
-      fun `cannot get a report by incident number if it is not found`() {
-        webTestClient.get().uri("/incident-reports/incident-number/IR-11111111/with-details")
+      fun `cannot get a report by reference if it is not found`() {
+        webTestClient.get().uri("/incident-reports/reference/IR-11111111/with-details")
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
           .header("Content-Type", "application/json")
           .exchange()
@@ -686,7 +686,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
     @Nested
     inner class HappyPath {
       @Test
-      fun `can get a report by incident number`() {
+      fun `can get a report by reference`() {
         webTestClient.get().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_INCIDENT_REPORTS"), scopes = listOf("read")))
           .header("Content-Type", "application/json")
@@ -697,7 +697,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "${existingReport.id}",
-              "incidentNumber": "IR-0000000001124143",
+              "reportReference": "IR-0000000001124143",
               "type": "FINDS",
               "incidentDateAndTime": "2023-12-05T11:34:56",
               "prisonId": "MDI",
@@ -1088,7 +1088,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "${existingReport.id}",
-              "incidentNumber": "IR-0000000001124143",
+              "reportReference": "IR-0000000001124143",
               "type": "FINDS",
               "incidentDateAndTime": "2023-12-05T11:34:56",
               "prisonId": "MDI",
@@ -1129,7 +1129,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "${existingReport.id}",
-              "incidentNumber": "IR-0000000001124143",
+              "reportReference": "IR-0000000001124143",
               "type": "FINDS",
               "incidentDateAndTime": "2023-12-05T10:34:56",
               "prisonId": "LEI",
@@ -1196,7 +1196,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "${existingReport.id}",
-              "incidentNumber": "IR-0000000001124143",
+              "reportReference": "IR-0000000001124143",
               "type": "FINDS",
               "incidentDateAndTime": "$expectedIncidentDateAndTime",
               "prisonId": "$expectedPrisonId",
@@ -1385,7 +1385,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "${existingReport.id}",
-              "incidentNumber": "IR-0000000001124143",
+              "reportReference": "IR-0000000001124143",
               "type": "FINDS",
               "incidentDateAndTime": "2023-12-05T11:34:56",
               "prisonId": "MDI",
@@ -1427,7 +1427,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "${existingReport.id}",
-              "incidentNumber": "IR-0000000001124143",
+              "reportReference": "IR-0000000001124143",
               "type": "FINDS",
               "incidentDateAndTime": "2023-12-05T11:34:56",
               "prisonId": "MDI",
@@ -1572,7 +1572,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
       fun `can change type of a report but keeping it the same`() {
         val reportWithQuestions = reportRepository.save(
           buildIncidentReport(
-            incidentNumber = "IR-0000000001124146",
+            reportReference = "IR-0000000001124146",
             reportTime = now.minusMinutes(3),
             status = Status.AWAITING_ANALYSIS,
             generateQuestions = 2,
@@ -1596,7 +1596,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """
             {
               "id": "${reportWithQuestions.id}",
-              "incidentNumber": "IR-0000000001124146",
+              "reportReference": "IR-0000000001124146",
               "type": "FINDS",
               "incidentDateAndTime": "2023-12-05T11:31:56",
               "prisonId": "MDI",
@@ -1663,7 +1663,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
       fun `can change type of a report creating history when there was none`() {
         val reportWithQuestions = reportRepository.save(
           buildIncidentReport(
-            incidentNumber = "IR-0000000001124146",
+            reportReference = "IR-0000000001124146",
             reportTime = now.minusMinutes(3),
             status = Status.AWAITING_ANALYSIS,
             generateQuestions = 2,
@@ -1682,7 +1682,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """
             {
               "id": "${reportWithQuestions.id}",
-              "incidentNumber": "IR-0000000001124146",
+              "reportReference": "IR-0000000001124146",
               "type": "DAMAGE",
               "incidentDateAndTime": "2023-12-05T11:31:56",
               "prisonId": "MDI",
@@ -1761,7 +1761,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
       fun `can change type of a report preserving history when it already existed`() {
         val reportWithQuestionsAndHistory = reportRepository.save(
           buildIncidentReport(
-            incidentNumber = "IR-0000000001124146",
+            reportReference = "IR-0000000001124146",
             reportTime = now.minusMinutes(3),
             status = Status.AWAITING_ANALYSIS,
             generateQuestions = 1,
@@ -1780,7 +1780,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """
             {
               "id": "${reportWithQuestionsAndHistory.id}",
-              "incidentNumber": "IR-0000000001124146",
+              "reportReference": "IR-0000000001124146",
               "type": "DAMAGE",
               "incidentDateAndTime": "2023-12-05T11:31:56",
               "prisonId": "MDI",
@@ -1908,7 +1908,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "$reportId",
-              "incidentNumber": "IR-0000000001124143"
+              "reportReference": "IR-0000000001124143"
             }
             """,
             false,
@@ -1931,7 +1931,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
         existingReport.event.addReport(
           buildIncidentReport(
-            incidentNumber = "IR-0000000001124142",
+            reportReference = "IR-0000000001124142",
             reportTime = now.minusMinutes(5),
           ),
         )
@@ -1948,7 +1948,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             """ 
             {
               "id": "$reportId",
-              "incidentNumber": "IR-0000000001124143"
+              "reportReference": "IR-0000000001124143"
             }
             """,
             false,
@@ -1975,7 +1975,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
       existingReportWithRelatedObjects = reportRepository.save(
         buildIncidentReport(
-          incidentNumber = "IR-0000000001124146",
+          reportReference = "IR-0000000001124146",
           reportTime = now,
           generateStaffInvolvement = 2,
           generatePrisonerInvolvement = 2,
@@ -2606,7 +2606,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
 
       existingReportWithQuestionsAndResponses = reportRepository.save(
         buildIncidentReport(
-          incidentNumber = "IR-0000000001124146",
+          reportReference = "IR-0000000001124146",
           reportTime = now,
           generateQuestions = 2,
           generateResponses = 2,
@@ -2680,7 +2680,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         fun `can list 50 questions and responses`() {
           val report = reportRepository.save(
             buildIncidentReport(
-              incidentNumber = "IR-0000000001124147",
+              reportReference = "IR-0000000001124147",
               reportTime = now,
               generateQuestions = 50,
               generateResponses = 3,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
@@ -158,7 +158,7 @@ class NomisSyncServiceTest {
     description = "Offender was found in own cell with a razor",
     prisonId = "MDI",
     event = Event(
-      eventId = "112414323",
+      eventReference = "112414323",
       eventDateAndTime = whenIncidentHappened,
       prisonId = "MDI",
       title = "Cutting",
@@ -199,7 +199,7 @@ class NomisSyncServiceTest {
 
   /** compare report entity about to be saved with the mocked response */
   private fun isEqualToSampleReport(report: Report, expectedId: UUID?): Boolean {
-    // NB: cannot compare arg to sampleReport because IncidentReport.equals only compares incidentNumber
+    // NB: cannot compare arg to sampleReport directly
     return report.id == expectedId &&
       report.incidentNumber == sampleReport.incidentNumber &&
       report.incidentDateAndTime == sampleReport.incidentDateAndTime &&
@@ -220,9 +220,9 @@ class NomisSyncServiceTest {
 
   /** compare event entity about to be saved with the mocked response */
   private fun isEqualToSampleEvent(event: Event): Boolean {
-    // NB: cannot compare arg to sampleReport because IncidentEvent.equals only compares eventId
+    // NB: cannot compare arg to sampleReport directly
     val sampleEvent = sampleReport.event
-    return event.eventId == sampleEvent.eventId &&
+    return event.eventReference == sampleEvent.eventReference &&
       event.eventDateAndTime == sampleEvent.eventDateAndTime &&
       event.prisonId == sampleEvent.prisonId &&
       event.description == sampleEvent.description &&
@@ -239,7 +239,7 @@ class NomisSyncServiceTest {
     assertThat(report.prisonId).isEqualTo("MDI")
     assertThat(report.title).isEqualTo("Cutting")
     assertThat(report.description).isEqualTo("Offender was found in own cell with a razor")
-    assertThat(report.event.eventId).isEqualTo("112414323")
+    assertThat(report.event.eventReference).isEqualTo("112414323")
     assertThat(report.event.eventDateAndTime).isEqualTo(whenIncidentHappened)
     assertThat(report.event.description).isEqualTo("Offender was found in own cell with a razor")
     assertThat(report.event.prisonId).isEqualTo("MDI")
@@ -410,7 +410,7 @@ class NomisSyncServiceTest {
   }
 
   @ParameterizedTest(name = "throws report-already-exists exception if {0} constraint failed")
-  @ValueSource(strings = ["event_id", "incident_number"])
+  @ValueSource(strings = ["event_reference", "incident_number"])
   fun `throws report-already-exists exception if identifier constraints failed`(constraint: String) {
     val syncRequest = sampleSyncRequest.copy(
       id = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
@@ -151,7 +151,7 @@ class NomisSyncServiceTest {
   /** saved entity based on successful `sampleSyncRequest` */
   private val sampleReport = Report(
     id = sampleReportId,
-    incidentNumber = "112414323",
+    reportReference = "112414323",
     incidentDateAndTime = whenIncidentHappened,
     type = Type.SELF_HARM,
     title = "Cutting",
@@ -201,7 +201,7 @@ class NomisSyncServiceTest {
   private fun isEqualToSampleReport(report: Report, expectedId: UUID?): Boolean {
     // NB: cannot compare arg to sampleReport directly
     return report.id == expectedId &&
-      report.incidentNumber == sampleReport.incidentNumber &&
+      report.reportReference == sampleReport.reportReference &&
       report.incidentDateAndTime == sampleReport.incidentDateAndTime &&
       report.type == sampleReport.type &&
       report.title == sampleReport.title &&
@@ -233,7 +233,7 @@ class NomisSyncServiceTest {
 
   private fun assertSampleReportConvertedToDto(report: ReportWithDetails) {
     assertThat(report.id).isEqualTo(sampleReportId)
-    assertThat(report.incidentNumber).isEqualTo("112414323")
+    assertThat(report.reportReference).isEqualTo("112414323")
     assertThat(report.type).isEqualTo(Type.SELF_HARM)
     assertThat(report.incidentDateAndTime).isEqualTo(whenIncidentHappened)
     assertThat(report.prisonId).isEqualTo("MDI")
@@ -329,7 +329,7 @@ class NomisSyncServiceTest {
         "created" to "true",
         "updated" to "false",
         "id" to "11111111-2222-3333-4444-555555555555",
-        "incidentNumber" to "112414323",
+        "reportReference" to "112414323",
         "prisonId" to "MDI",
       ),
       null,
@@ -360,7 +360,7 @@ class NomisSyncServiceTest {
         "created" to "false",
         "updated" to "true",
         "id" to "11111111-2222-3333-4444-555555555555",
-        "incidentNumber" to "112414323",
+        "reportReference" to "112414323",
         "prisonId" to "MDI",
       ),
       null,
@@ -410,7 +410,7 @@ class NomisSyncServiceTest {
   }
 
   @ParameterizedTest(name = "throws report-already-exists exception if {0} constraint failed")
-  @ValueSource(strings = ["event_reference", "incident_number"])
+  @ValueSource(strings = ["event_reference", "report_reference"])
   fun `throws report-already-exists exception if identifier constraints failed`(constraint: String) {
     val syncRequest = sampleSyncRequest.copy(
       id = null,

--- a/src/test/resources/entity-mapping/sample-report-basic.json
+++ b/src/test/resources/entity-mapping/sample-report-basic.json
@@ -1,5 +1,5 @@
 {
-  "incidentNumber": "IR-0000000001124143",
+  "reportReference": "IR-0000000001124143",
   "type": "FINDS",
   "incidentDateAndTime": "2023-12-05T11:34:56",
   "prisonId": "MDI",

--- a/src/test/resources/entity-mapping/sample-report-with-details.json
+++ b/src/test/resources/entity-mapping/sample-report-with-details.json
@@ -1,5 +1,5 @@
 {
-  "incidentNumber": "IR-0000000001124143",
+  "reportReference": "IR-0000000001124143",
   "type": "FINDS",
   "incidentDateAndTime": "2023-12-05T11:34:56",
   "prisonId": "MDI",

--- a/src/test/resources/entity-mapping/sample-report-with-details.json
+++ b/src/test/resources/entity-mapping/sample-report-with-details.json
@@ -14,7 +14,7 @@
   "modifiedBy": "USER1",
   "createdInNomis": false,
   "event": {
-    "eventId": "IE-0000000001124143",
+    "eventReference": "IE-0000000001124143",
     "eventDateAndTime": "2023-12-05T11:34:56",
     "prisonId": "MDI",
     "title": "An event occurred",


### PR DESCRIPTION
1. To make the human-visible identifiers consistent, it’d be good to name them similarly.
2. Human-visible identifier for Event sounds an awful lot like its primary key – both were basically “event ID“

`Event.eventId` → `Event.eventReference`
`Report.incidentNumber` → `Report.reportReference`

TODO:
- **drop all deployed databases before merging!**
- [update HMPPS domain events docs](https://github.com/ministryofjustice/hmpps-domain-events/pull/38)
- [update NOMIS migration/reconciliation](https://github.com/ministryofjustice/hmpps-prisoner-from-nomis-migration/pull/720)