### PR TITLE
IR-383: Event uses UUID as primary key, not longs

### DIFF
--- a/docs/0004-modeling-irs.md
+++ b/docs/0004-modeling-irs.md
@@ -25,7 +25,7 @@ classDiagram
         CorrectionReason  reason
     }
     class Event {
-        Long  id
+        UUID  id
         LocalDateTime  createdAt
         String  description
         LocalDateTime  eventDateAndTime
@@ -152,7 +152,7 @@ classDiagram
         timestamp created_at
         varchar(120) modified_by
         timestamp modified_at
-        integer id
+        uuid id
     }
     class evidence {
         uuid report_id
@@ -208,7 +208,7 @@ classDiagram
         integer id
     }
     class report {
-        integer event_id
+        uuid event_id
         varchar(25) report_reference
         varchar(255) title
         text description

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
@@ -4,11 +4,11 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.id.GeneratedUuidV7
 import java.time.LocalDateTime
+import java.util.UUID
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Event as EventDto
 
 @Entity
@@ -17,8 +17,9 @@ class Event(
    * Internal ID which should not be seen by users
    */
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val id: Long? = null,
+  @GeneratedUuidV7
+  @Column(name = "id", updatable = false, nullable = false)
+  val id: UUID? = null,
 
   /**
    * Human-readable reference.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/EventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/repository/EventRepository.kt
@@ -4,9 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Event
+import java.util.UUID
 
 @Repository
-interface EventRepository : JpaRepository<Event, Long> {
+interface EventRepository : JpaRepository<Event, UUID> {
   fun findOneByEventReference(eventReference: String): Event?
 
   @Query(value = "SELECT nextval('event_sequence')", nativeQuery = true)

--- a/src/main/resources/db/migration/V1_1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1_1__initial_schema.sql
@@ -1,6 +1,6 @@
 create table event
 (
-    id                  serial
+    id                  uuid                                not null
         constraint event_pk primary key,
     event_reference     varchar(25)                         not null
         constraint event_reference unique,
@@ -26,7 +26,7 @@ create table report
 (
     id                     uuid                                 not null
         constraint report_pk primary key,
-    event_id               integer                              not null
+    event_id               uuid                                 not null
         constraint report_event_fk references event (id) on delete restrict,
     report_reference       varchar(25)                          not null
         constraint report_reference unique,


### PR DESCRIPTION
This is for consistency with the Report model/table and it can aid against URL-browsing to other events as IDs are now difficult to predict.