### PR TITLE
IR-395: React to HMPPS prisoner merge domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Event.kt
@@ -34,7 +34,7 @@ class Event(
   @Id
   @GeneratedUuidV7
   @Column(name = "id", updatable = false, nullable = false)
-  val id: UUID? = null,
+  var id: UUID? = null,
 
   /**
    * Human-readable reference.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -64,7 +64,7 @@ class Report(
   @Id
   @GeneratedUuidV7
   @Column(name = "id", updatable = false, nullable = false)
-  val id: UUID? = null,
+  var id: UUID? = null,
 
   /**
    * Human-readable reference. Previously known as ”incident number” in NOMIS.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonOffenderEventListener.kt
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class PrisonOffenderEventListener(
+  private val reportService: ReportService,
   private val mapper: ObjectMapper,
 ) {
   companion object {
@@ -28,8 +29,8 @@ class PrisonOffenderEventListener(
     when (eventType) {
       PRISONER_MERGE_EVENT_TYPE -> {
         val mergeEvent = mapper.readValue(message, HMPPSMergeDomainEvent::class.java)
-        // TODO: This is a no-op for now
-        log.debug("Ignoring '$PRISONER_MERGE_EVENT_TYPE' message")
+        val (removedPrisonerNumber, prisonerNumber) = mergeEvent.additionalInformation
+        reportService.replacePrisonerNumber(removedPrisonerNumber, prisonerNumber)
       }
       else -> {
         log.debug("Ignoring message with type $eventType")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonerMergeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonerMergeTest.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.service
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.incidentreporting.helper.buildReport
+import uk.gov.justice.digital.hmpps.incidentreporting.integration.IntegrationTestBase.Companion.clock
+import uk.gov.justice.digital.hmpps.incidentreporting.integration.IntegrationTestBase.Companion.now
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.EventRepository
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.PrisonerInvolvementRepository
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepository
+import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
+import java.util.UUID
+
+class PrisonerMergeTest {
+  private val reportRepository: ReportRepository = mock()
+  private val eventRepository: EventRepository = mock()
+  private val prisonerInvolvementRepository: PrisonerInvolvementRepository = mock()
+  private val authenticationHolder: HmppsAuthenticationHolder = mock()
+  private val telemetryClient: TelemetryClient = mock()
+
+  private val reportService = ReportService(
+    reportRepository = reportRepository,
+    eventRepository = eventRepository,
+    prisonerInvolvementRepository = prisonerInvolvementRepository,
+    telemetryClient = telemetryClient,
+    authenticationHolder = authenticationHolder,
+    clock = clock,
+  )
+
+  @Test
+  fun `returns empty list when no rename takes place`() {
+    whenever(prisonerInvolvementRepository.findAllByPrisonerNumber("A0002AA"))
+      .thenReturn(emptyList())
+
+    val reports = reportService.replacePrisonerNumber("A0002AA", "A0002BB")
+    assertThat(reports).isEmpty()
+  }
+
+  @Test
+  fun `can replace all instances of a prisoner number in prisoner involvement entities`() {
+    // report with A0001AA
+    val mockReport1 = buildReport(
+      reportReference = "94728",
+      reportTime = now.minusDays(3),
+      generatePrisonerInvolvement = 1,
+    ).also { it.id = UUID.fromString("066ab92f-efc5-7015-8000-42c0bc6b704b") }
+    // report with A0001AA and A0002AA
+    val mockReport2 = buildReport(
+      reportReference = "IR-0000000001124143",
+      reportTime = now.minusDays(2),
+      generatePrisonerInvolvement = 2,
+    ).also { it.id = UUID.fromString("066ab930-b9ef-7b6d-8000-23258e439e22") }
+    // report with A0001AA, A0002AA and A0003AA
+    val mockReport3 = buildReport(
+      reportReference = "IR-0000000001124146",
+      reportTime = now.minusDays(1),
+      generatePrisonerInvolvement = 3,
+    ).also { it.id = UUID.fromString("066ab931-77d5-70fc-8000-67fbea4733e5") }
+    val mockReports = listOf(mockReport1, mockReport2, mockReport3)
+    val mockPrisonerInvolvements = mockReports
+      .flatMap { it.prisonersInvolved }
+      .filter { it.prisonerNumber == "A0002AA" }
+
+    whenever(prisonerInvolvementRepository.findAllByPrisonerNumber("A0002AA"))
+      .thenReturn(mockPrisonerInvolvements)
+
+    val reports = reportService.replacePrisonerNumber("A0002AA", "A0002BB")
+    val reportIds = reports.map { it.reportReference }
+    assertThat(reportIds)
+      .isEqualTo(listOf("IR-0000000001124143", "IR-0000000001124146"))
+
+    assertThat(mockReport1.prisonersInvolved.map { it.prisonerNumber })
+      .isEqualTo(listOf("A0001AA"))
+    assertThat(mockReport2.prisonersInvolved.map { it.prisonerNumber })
+      .isEqualTo(listOf("A0001AA", "A0002BB"))
+    assertThat(mockReport3.prisonersInvolved.map { it.prisonerNumber })
+      .isEqualTo(listOf("A0001AA", "A0002BB", "A0003AA"))
+    assertThat(mockReport1.modifiedAt).isBefore(now)
+    assertThat(mockReport2.modifiedAt).isEqualTo(now)
+    assertThat(mockReport3.modifiedAt).isEqualTo(now)
+  }
+
+  @Test
+  fun `does not deduplicate situations where a prisoner number is involved more than once`() {
+    // report with A0001AA and A0002AA
+    val mockReport = buildReport(
+      reportReference = "94728",
+      reportTime = now,
+      generatePrisonerInvolvement = 2,
+    ).also { it.id = UUID.fromString("066ab92f-efc5-7015-8000-42c0bc6b704b") }
+    val mockPrisonerInvolvements = mockReport.prisonersInvolved
+      .filter { it.prisonerNumber == "A0002AA" }
+
+    whenever(prisonerInvolvementRepository.findAllByPrisonerNumber("A0002AA"))
+      .thenReturn(mockPrisonerInvolvements)
+
+    val reports = reportService.replacePrisonerNumber("A0002AA", "A0001AA")
+    val reportIds = reports.map { it.reportReference }
+    assertThat(reportIds)
+      .isEqualTo(listOf("94728"))
+
+    assertThat(mockReport.prisonersInvolved.map { it.prisonerNumber })
+      .isEqualTo(listOf("A0001AA", "A0001AA"))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonerMergeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonerMergeTest.kt
@@ -2,8 +2,16 @@ package uk.gov.justice.digital.hmpps.incidentreporting.service
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.incidentreporting.helper.buildReport
 import uk.gov.justice.digital.hmpps.incidentreporting.integration.IntegrationTestBase.Companion.clock
@@ -14,6 +22,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.repository.ReportRepos
 import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
 import java.util.UUID
 
+@DisplayName("Prisoner merging")
 class PrisonerMergeTest {
   private val reportRepository: ReportRepository = mock()
   private val eventRepository: EventRepository = mock()
@@ -37,6 +46,9 @@ class PrisonerMergeTest {
 
     val reports = reportService.replacePrisonerNumber("A0002AA", "A0002BB")
     assertThat(reports).isEmpty()
+
+    verify(telemetryClient, never())
+      .trackEvent(any(), any(), anyOrNull())
   }
 
   @Test
@@ -81,6 +93,9 @@ class PrisonerMergeTest {
     assertThat(mockReport1.modifiedAt).isBefore(now)
     assertThat(mockReport2.modifiedAt).isEqualTo(now)
     assertThat(mockReport3.modifiedAt).isEqualTo(now)
+
+    verify(telemetryClient, times(2))
+      .trackEvent(eq("Prisoner A0002AA merged into A0002BB"), any(), isNull())
   }
 
   @Test


### PR DESCRIPTION
…by replacing given prisoner number in all involvement entities.

Open question remains: if reports and events will have auto-generated titles, and if prisoner numbers are included, we should rename these too