### PR TITLE
IR-401: Add date field to responses

### DIFF
--- a/docs/0004-modeling-irs.md
+++ b/docs/0004-modeling-irs.md
@@ -47,6 +47,7 @@ classDiagram
         LocalDateTime  recordedAt
         String  recordedBy
         String  response
+        LocalDate  responseDate
     }
     class History {
         Long  id
@@ -91,6 +92,7 @@ classDiagram
         LocalDateTime  recordedAt
         String  recordedBy
         String  response
+        LocalDate  responseDate
     }
     class StaffInvolvement {
         Long  id
@@ -110,7 +112,6 @@ HistoricalQuestion "0..*" <--> "1" History
 HistoricalResponse "0..*" <--> "1" HistoricalQuestion
 Question "1" <--> "0..*" Response
 Report "1..*" <--> "1" Event
-Report "1" <--> "0..*" Evidence
 Report "1" <--> "0..*" History
 Report "1" <--> "0..*" PrisonerInvolvement
 Report "1" <--> "0..*" Question
@@ -154,6 +155,7 @@ classDiagram
         integer historical_question_id
         integer sequence
         text response
+        date response_date
         text additional_information
         timestamp recorded_at
         varchar(120) recorded_by
@@ -205,6 +207,7 @@ classDiagram
         integer question_id
         integer sequence
         text response
+        date response_date
         text additional_information
         timestamp recorded_at
         varchar(120) recorded_by

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalResponse.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.incidentreporting.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Schema(description = "Previous response to a question making up a previous version of an incident report")
@@ -9,10 +10,13 @@ import java.time.LocalDateTime
 data class HistoricalResponse(
   @Schema(description = "The response", required = true)
   val response: String,
+  @Schema(description = "Optional response as a date", required = false, example = "2024-04-29")
+  val responseDate: LocalDate? = null,
+  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  val additionalInformation: String? = null,
+
   @Schema(description = "Username of person who responded to the question", required = true)
   val recordedBy: String,
   @Schema(description = "When the response was made", required = true, example = "2024-04-29T12:34:56.789012")
   val recordedAt: LocalDateTime,
-  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
-  val additionalInformation: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Response.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.incidentreporting.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Schema(description = "Response to a question making up an incident report")
@@ -9,10 +10,13 @@ import java.time.LocalDateTime
 data class Response(
   @Schema(description = "The response", required = true)
   val response: String,
+  @Schema(description = "Optional response as a date", required = false, example = "2024-04-29")
+  val responseDate: LocalDate? = null,
+  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  val additionalInformation: String? = null,
+
   @Schema(description = "Username of person who responded to the question", required = true)
   val recordedBy: String,
   @Schema(description = "When the response was made", required = true, example = "2024-04-29T12:34:56.789012")
   val recordedAt: LocalDateTime,
-  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
-  val additionalInformation: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/Mapping.kt
@@ -95,6 +95,7 @@ fun Report.addNomisQuestions(questions: Collection<NomisQuestion>) {
       .forEach { answer ->
         dataItem.addResponse(
           response = answer.answer!!,
+          responseDate = answer.responseDate,
           additionalInformation = answer.comment,
           recordedBy = answer.recordingStaff.username,
           recordedAt = this.reportedAt,
@@ -122,6 +123,7 @@ fun Report.addNomisHistory(histories: Collection<NomisHistory>) {
         .forEach { answer ->
           dataItem.addResponse(
             response = answer.answer!!,
+            responseDate = answer.responseDate,
             additionalInformation = answer.comment,
             recordedBy = answer.recordingStaff.username,
             recordedAt = this.reportedAt,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/NomisHistoryResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/NomisHistoryResponse.kt
@@ -12,11 +12,10 @@ data class NomisHistoryResponse(
   val responseSequence: Int,
   @Schema(description = "The answer text")
   val answer: String?,
+  @Schema(description = "Response date added to the response by recording staff")
+  val responseDate: LocalDate? = null,
   @Schema(description = "Comment added to the response by recording staff")
   val comment: String?,
   @Schema(description = "Recording staff")
   val recordingStaff: NomisStaff,
-
-  @Schema(description = "Response date added to the response by recording staff")
-  val responseDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/NomisResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/NomisResponse.kt
@@ -13,11 +13,13 @@ data class NomisResponse(
   val sequence: Int,
   @Schema(description = "The answer text")
   val answer: String?,
-  @Schema(description = "Comment added to the response by recording staff")
-  val comment: String?,
-
   @Schema(description = "Response date added to the response by recording staff")
   val responseDate: LocalDate? = null,
+  @Schema(description = "Comment added to the response by recording staff")
+  val comment: String?,
+  @Schema(description = "Recording staff")
+  val recordingStaff: NomisStaff,
+
   @Schema(description = "The date and time the response was created")
   val createDateTime: LocalDateTime,
   @Schema(description = "The username of the person who created the response")
@@ -26,7 +28,4 @@ data class NomisResponse(
   val lastModifiedDateTime: LocalDateTime? = createDateTime,
   @Schema(description = "The username of the person who last updated the response")
   val lastModifiedBy: String? = createdBy,
-
-  @Schema(description = "Recording staff")
-  val recordingStaff: NomisStaff,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
+import java.time.LocalDate
 
 @Schema(description = "Payload to add question with responses to an incident report")
 data class AddQuestionWithResponses(
@@ -24,6 +25,8 @@ data class AddQuestionResponse(
   @Schema(description = "The response", required = true, minLength = 1)
   @field:Size(min = 1)
   val response: String,
+  @Schema(description = "Optional response as a date", required = false, example = "2024-04-29")
+  val responseDate: LocalDate? = null,
   @Schema(description = "Optional additional information", required = false, defaultValue = "null")
   val additionalInformation: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderColumn
 import org.hibernate.annotations.BatchSize
+import java.time.LocalDate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.HistoricalQuestion as HistoricalQuestionDto
 
@@ -22,9 +23,9 @@ class HistoricalQuestion(
   @ManyToOne(fetch = FetchType.LAZY)
   val history: History,
 
+  // TODO: decide how this works and if it is ever unique (eg within 1 report)
   val code: String,
   val question: String,
-
   val additionalInformation: String? = null,
 
   @OneToMany(mappedBy = "historicalQuestion", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
@@ -40,6 +41,7 @@ class HistoricalQuestion(
 
   fun addResponse(
     response: String,
+    responseDate: LocalDate? = null,
     additionalInformation: String? = null,
     recordedBy: String,
     recordedAt: LocalDateTime,
@@ -48,9 +50,10 @@ class HistoricalQuestion(
       HistoricalResponse(
         historicalQuestion = this,
         response = response,
+        responseDate = responseDate,
+        additionalInformation = additionalInformation,
         recordedBy = recordedBy,
         recordedAt = recordedAt,
-        additionalInformation = additionalInformation,
       ),
     )
     return this

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
+import java.time.LocalDate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.HistoricalResponse as HistoricalResponseDto
 
@@ -20,7 +21,7 @@ class HistoricalResponse(
 
   // TODO: should we add a `val code: String` like in Question?
   val response: String,
-
+  val responseDate: LocalDate? = null,
   val additionalInformation: String? = null,
 
   val recordedBy: String,
@@ -32,6 +33,7 @@ class HistoricalResponse(
 
   fun toDto() = HistoricalResponseDto(
     response = response,
+    responseDate = responseDate,
     recordedBy = recordedBy,
     recordedAt = recordedAt,
     additionalInformation = additionalInformation,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderColumn
 import org.hibernate.annotations.BatchSize
+import java.time.LocalDate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Question as QuestionDto
 
@@ -24,9 +25,7 @@ class Question(
 
   // TODO: decide how this works and if it is ever unique (eg within 1 report)
   val code: String,
-
   val question: String,
-
   val additionalInformation: String? = null,
 
   @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
@@ -44,6 +43,7 @@ class Question(
 
   fun addResponse(
     response: String,
+    responseDate: LocalDate? = null,
     additionalInformation: String? = null,
     recordedBy: String,
     recordedAt: LocalDateTime,
@@ -52,9 +52,10 @@ class Question(
       Response(
         question = this,
         response = response,
+        responseDate = responseDate,
+        additionalInformation = additionalInformation,
         recordedBy = recordedBy,
         recordedAt = recordedAt,
-        additionalInformation = additionalInformation,
       ),
     )
     return this

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -237,6 +237,7 @@ class Report(
       question.getResponses().forEach { response ->
         historicalQuestion.addResponse(
           response.response,
+          response.responseDate,
           response.additionalInformation,
           response.recordedBy,
           response.recordedAt,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
+import java.time.LocalDate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.Response as ResponseDto
 
@@ -20,7 +21,7 @@ class Response(
 
   // TODO: should we add a `val code: String` like in Question?
   val response: String,
-
+  val responseDate: LocalDate? = null,
   val additionalInformation: String? = null,
 
   val recordedBy: String,
@@ -32,6 +33,7 @@ class Response(
 
   fun toDto() = ResponseDto(
     response = response,
+    responseDate = responseDate,
     recordedBy = recordedBy,
     recordedAt = recordedAt,
     additionalInformation = additionalInformation,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -283,6 +283,7 @@ class ReportService(
         addRequest.responses.forEach {
           addResponse(
             response = it.response,
+            responseDate = it.responseDate,
             recordedBy = requestUsername,
             recordedAt = now,
             additionalInformation = it.additionalInformation,

--- a/src/main/resources/db/migration/V1_1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1_1__initial_schema.sql
@@ -135,6 +135,7 @@ create table response
         constraint response_question_fk references question (id) on delete cascade,
     sequence               integer   default 0                 not null,
     response               text                                not null,
+    response_date          date,
     additional_information text,
     recorded_at            timestamp default CURRENT_TIMESTAMP not null,
     recorded_by            varchar(120)                        not null
@@ -177,6 +178,7 @@ create table historical_response
         constraint historical_response_historical_question_fk references historical_question (id) on delete cascade,
     sequence               integer   default 0                 not null,
     response               text                                not null,
+    response_date          date,
     additional_information text,
     recorded_at            timestamp default CURRENT_TIMESTAMP not null,
     recorded_by            varchar(120)                        not null

--- a/src/main/resources/db/migration/V1_1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1_1__initial_schema.sql
@@ -131,13 +131,13 @@ create table response
 (
     id                     serial
         constraint response_pk primary key,
-    question_id            integer                                not null
+    question_id            integer                             not null
         constraint response_question_fk references question (id) on delete cascade,
-    sequence               integer      default 0                 not null,
-    response               text                                   not null,
+    sequence               integer   default 0                 not null,
+    response               text                                not null,
     additional_information text,
-    recorded_at            timestamp    default CURRENT_TIMESTAMP not null,
-    recorded_by            varchar(120) default 'system'          not null
+    recorded_at            timestamp default CURRENT_TIMESTAMP not null,
+    recorded_by            varchar(120)                        not null
 );
 
 create index response_sequence_at_idx on response (sequence);
@@ -173,13 +173,13 @@ create table historical_response
 (
     id                     serial
         constraint historical_response_pk primary key,
-    historical_question_id integer                                not null
+    historical_question_id integer                             not null
         constraint historical_response_historical_question_fk references historical_question (id) on delete cascade,
-    sequence               integer      default 0                 not null,
-    response               text                                   not null,
+    sequence               integer   default 0                 not null,
+    response               text                                not null,
     additional_information text,
-    recorded_at            timestamp    default CURRENT_TIMESTAMP not null,
-    recorded_by            varchar(120) default 'system'          not null
+    recorded_at            timestamp default CURRENT_TIMESTAMP not null,
+    recorded_by            varchar(120)                        not null
 );
 
 create index historical_response_sequence_at_idx on historical_response (sequence);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
@@ -89,6 +89,7 @@ fun buildReport(
     (1..generateResponses).forEach { responseIndex ->
       question.addResponse(
         response = "Response #$responseIndex",
+        responseDate = eventDateAndTime.toLocalDate().minusDays(responseIndex.toLong()),
         additionalInformation = "Prose #$responseIndex",
         recordedBy = "some-user",
         recordedAt = reportTime,
@@ -111,6 +112,7 @@ fun buildReport(
       (1..generateResponses).forEach { responseIndex ->
         historicalQuestion.addResponse(
           response = "Historical response #$historyIndex-$responseIndex",
+          responseDate = eventDateAndTime.toLocalDate().minusDays(responseIndex.toLong()),
           additionalInformation = "Prose #$responseIndex in history #$historyIndex",
           recordedBy = "some-user",
           recordedAt = reportTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -259,27 +259,27 @@ class ReportRepositoryTest : IntegrationTestBase() {
       ?: throw EntityNotFoundException()
 
     report.addQuestion("WHERE_OCCURRED", "Where did this occur?")
-      .addResponse("DETOX_UNIT", "They hurt themselves", "user1", now)
-      .addResponse("CELL", "In the cell", "user1", now)
+      .addResponse("DETOX_UNIT", null, "They hurt themselves", "user1", now)
+      .addResponse("CELL", null, "In the cell", "user1", now)
 
     report.addQuestion("METHOD", "Method Used to hurt themselves?")
-      .addResponse("KNIFE", "They used a knife", "user1", now)
-      .addResponse("OTHER", "They used something else", "user1", now)
+      .addResponse("KNIFE", null, "They used a knife", "user1", now)
+      .addResponse("OTHER", null, "They used something else", "user1", now)
 
     report.addQuestion("BLAH", "Blah?")
-      .addResponse("HEAD", "Head", "user1", now)
-      .addResponse("ARM", "Arm", "user1", now)
+      .addResponse("HEAD", null, "Head", "user1", now)
+      .addResponse("ARM", null, "Arm", "user1", now)
 
     report.addHistory(Type.FINDS, halfHourAgo, "user2")
       .addQuestion("FINDS-Q1", "Finds question 1")
-      .addResponse("response1", "Some information 1", "user1", halfHourAgo)
-      .addResponse("response2", "Some information 2", "user1", halfHourAgo)
-      .addResponse("response3", "Some information 3", "user1", halfHourAgo)
+      .addResponse("response1", null, "Some information 1", "user1", halfHourAgo)
+      .addResponse("response2", null, "Some information 2", "user1", halfHourAgo)
+      .addResponse("response3", null, "Some information 3", "user1", halfHourAgo)
 
     report.addHistory(Type.ASSAULT, quarterHourAgo, "user1")
       .addQuestion("ASSAULT-Q1", "Assault question 1")
-      .addResponse("response4", "Some information 4", "user1", quarterHourAgo)
-      .addResponse("response5", "Some information 5", "user1", quarterHourAgo)
+      .addResponse("response4", null, "Some information 4", "user1", quarterHourAgo)
+      .addResponse("response5", null, "Some information 5", "user1", quarterHourAgo)
 
     TestTransaction.flagForCommit()
     TestTransaction.end()
@@ -290,10 +290,10 @@ class ReportRepositoryTest : IntegrationTestBase() {
     report.changeType(Type.ASSAULT, now, "user5")
 
     report.addQuestion("SOME_QUESTION", "Another question?")
-      .addResponse("YES", "Yes", "user1", now)
-      .addResponse("NO", "No", "user1", now)
-      .addResponse("MAYBE", "Maybe", "user1", now)
-      .addResponse("OTHER", "Other", "user1", now)
+      .addResponse("YES", null, "Yes", "user1", now)
+      .addResponse("NO", null, "No", "user1", now)
+      .addResponse("MAYBE", null, "Maybe", "user1", now)
+      .addResponse("OTHER", null, "Other", "user1", now)
 
     TestTransaction.flagForCommit()
     TestTransaction.end()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -153,6 +153,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 10,
                 1,
                 "Answer 1",
+                now.toLocalDate().minusDays(2),
                 "comment 1",
                 createDateTime = now,
                 createdBy = reportingStaff.username,
@@ -162,6 +163,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 11,
                 2,
                 "Answer 2",
+                null,
                 "comment 2",
                 createDateTime = now,
                 createdBy = reportingStaff.username,
@@ -171,7 +173,8 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 12,
                 3,
                 "Answer 3",
-                "comment 3",
+                now.toLocalDate().minusDays(3),
+                null,
                 createDateTime = now,
                 createdBy = reportingStaff.username,
                 recordingStaff = reportingStaff,
@@ -189,6 +192,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 13,
                 1,
                 "Answer 1",
+                now.toLocalDate().minusDays(1),
                 "comment 1",
                 createDateTime = now,
                 createdBy = reportingStaff.username,
@@ -198,6 +202,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 14,
                 2,
                 "Answer 2",
+                null,
                 "comment 2",
                 createDateTime = now,
                 createdBy = reportingStaff.username,
@@ -207,7 +212,18 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 15,
                 3,
                 "Answer 3",
-                "comment 3",
+                now.toLocalDate().minusDays(10),
+                null,
+                createDateTime = now,
+                createdBy = reportingStaff.username,
+                recordingStaff = reportingStaff,
+              ),
+              NomisResponse(
+                16,
+                4,
+                "Answer 4",
+                null,
+                null,
                 createDateTime = now,
                 createdBy = reportingStaff.username,
                 recordingStaff = reportingStaff,
@@ -225,6 +241,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 16,
                 1,
                 "Answer 1",
+                now.toLocalDate(),
                 "comment 1",
                 createDateTime = now,
                 createdBy = reportingStaff.username,
@@ -234,6 +251,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 17,
                 2,
                 "Answer 2",
+                null,
                 "comment 2",
                 createDateTime = now,
                 createdBy = reportingStaff.username,
@@ -243,7 +261,8 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 18,
                 3,
                 "Answer 3",
-                "comment 3",
+                now.toLocalDate().minusDays(7),
+                null,
                 createDateTime = now,
                 createdBy = reportingStaff.username,
                 recordingStaff = reportingStaff,
@@ -266,9 +285,9 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 1,
                 "Old question 1",
                 listOf(
-                  NomisHistoryResponse(1, 1, "Old answer 1", "comment 1", reportingStaff),
-                  NomisHistoryResponse(2, 2, "Old answer 2", "comment 2", reportingStaff),
-                  NomisHistoryResponse(3, 3, "Old answer 3", "comment 3", reportingStaff),
+                  NomisHistoryResponse(1, 1, "Old answer 1", now.toLocalDate(), "comment 1", reportingStaff),
+                  NomisHistoryResponse(2, 2, "Old answer 2", null, "comment 2", reportingStaff),
+                  NomisHistoryResponse(3, 3, "Old answer 3", now.toLocalDate().minusDays(7), null, reportingStaff),
                 ),
               ),
               NomisHistoryQuestion(
@@ -276,9 +295,9 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 2,
                 "Old question 2",
                 listOf(
-                  NomisHistoryResponse(4, 1, "Old answer 1", "comment 1", reportingStaff),
-                  NomisHistoryResponse(5, 2, "Old answer 2", "comment 2", reportingStaff),
-                  NomisHistoryResponse(6, 3, "Old answer 3", "comment 3", reportingStaff),
+                  NomisHistoryResponse(4, 1, "Old answer 1", now.toLocalDate().minusDays(1), "comment 1", reportingStaff),
+                  NomisHistoryResponse(5, 2, "Old answer 2", null, "comment 2", reportingStaff),
+                  NomisHistoryResponse(6, 3, "Old answer 3", now.toLocalDate().minusDays(8), null, reportingStaff),
                 ),
               ),
               NomisHistoryQuestion(
@@ -286,9 +305,9 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 3,
                 "Old question 3",
                 listOf(
-                  NomisHistoryResponse(7, 1, "Old answer 1", "comment 1", reportingStaff),
-                  NomisHistoryResponse(8, 2, "Old answer 2", "comment 2", reportingStaff),
-                  NomisHistoryResponse(9, 3, "Old answer 3", "comment 3", reportingStaff),
+                  NomisHistoryResponse(7, 1, "Old answer 1", null, null, reportingStaff),
+                  NomisHistoryResponse(8, 2, "Old answer 2", null, null, reportingStaff),
+                  NomisHistoryResponse(9, 3, "Old answer 3", null, null, reportingStaff),
                 ),
               ),
             ),
@@ -418,21 +437,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "responses": [
                       {
                         "response": "Answer 1",
+                        "responseDate": "2023-12-03",
+                        "additionalInformation": "comment 1",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 1"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 2",
+                        "responseDate": null,
+                        "additionalInformation": "comment 2",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 2"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 3",
+                        "responseDate": "2023-12-02",
+                        "additionalInformation": null,
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 3"
+                        "recordedAt": "2023-12-05T12:34:56"
                       }
                     ]
                   },
@@ -443,21 +465,31 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "responses": [
                       {
                         "response": "Answer 1",
+                        "responseDate": "2023-12-04",
+                        "additionalInformation": "comment 1",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 1"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 2",
+                        "responseDate": null,
+                        "additionalInformation": "comment 2",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 2"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 3",
+                        "responseDate": "2023-11-25",
+                        "additionalInformation": null,
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 3"
+                        "recordedAt": "2023-12-05T12:34:56"
+                      },
+                      {
+                        "response": "Answer 4",
+                        "responseDate": null,
+                        "additionalInformation": null,
+                        "recordedBy": "user2",
+                        "recordedAt": "2023-12-05T12:34:56"
                       }
                     ]
                   },
@@ -468,21 +500,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "responses": [
                       {
                         "response": "Answer 1",
+                        "responseDate": "2023-12-05",
+                        "additionalInformation": "comment 1",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 1"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 2",
+                        "responseDate": null,
+                        "additionalInformation": "comment 2",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 2"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 3",
+                        "responseDate": "2023-11-28",
+                        "additionalInformation": null,
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 3"
+                        "recordedAt": "2023-12-05T12:34:56"
                       }
                     ]
                   }
@@ -500,21 +535,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "responses": [
                           {
                             "response": "Old answer 1",
+                            "responseDate": "2023-12-05",
+                            "additionalInformation": "comment 1",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 2",
+                            "responseDate": null,
+                            "additionalInformation": "comment 2",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 3",
+                            "responseDate": "2023-11-28",
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 3"
+                            "recordedAt": "2023-12-05T12:34:56"
                           }
                         ]
                       },
@@ -525,21 +563,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "responses": [
                           {
                             "response": "Old answer 1",
+                            "responseDate": "2023-12-04",
+                            "additionalInformation": "comment 1",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 2",
+                            "responseDate": null,
+                            "additionalInformation": "comment 2",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 3",
+                            "responseDate": "2023-11-27",
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 3"
+                            "recordedAt": "2023-12-05T12:34:56"
                           }
                         ]
                       },
@@ -550,21 +591,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "responses": [
                           {
                             "response": "Old answer 1",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 2",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 3",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 3"
+                            "recordedAt": "2023-12-05T12:34:56"
                           }
                         ]
                       }
@@ -674,21 +718,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "responses": [
                       {
                         "response": "Answer 1",
+                        "responseDate": "2023-12-03",
+                        "additionalInformation": "comment 1",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 1"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 2",
+                        "responseDate": null,
+                        "additionalInformation": "comment 2",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 2"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 3",
+                        "responseDate": "2023-12-02",
+                        "additionalInformation": null,
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 3"
+                        "recordedAt": "2023-12-05T12:34:56"
                       }
                     ]
                   },
@@ -699,21 +746,31 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "responses": [
                       {
                         "response": "Answer 1",
+                        "responseDate": "2023-12-04",
+                        "additionalInformation": "comment 1",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 1"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 2",
+                        "responseDate": null,
+                        "additionalInformation": "comment 2",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 2"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 3",
+                        "responseDate": "2023-11-25",
+                        "additionalInformation": null,
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 3"
+                        "recordedAt": "2023-12-05T12:34:56"
+                      },
+                      {
+                        "response": "Answer 4",
+                        "responseDate": null,
+                        "additionalInformation": null,
+                        "recordedBy": "user2",
+                        "recordedAt": "2023-12-05T12:34:56"
                       }
                     ]
                   },
@@ -724,21 +781,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "responses": [
                       {
                         "response": "Answer 1",
+                        "responseDate": "2023-12-05",
+                        "additionalInformation": "comment 1",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 1"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 2",
+                        "responseDate": null,
+                        "additionalInformation": "comment 2",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 2"
+                        "recordedAt": "2023-12-05T12:34:56"
                       },
                       {
                         "response": "Answer 3",
+                        "responseDate": "2023-11-28",
+                        "additionalInformation": null,
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-05T12:34:56",
-                        "additionalInformation": "comment 3"
+                        "recordedAt": "2023-12-05T12:34:56"
                       }
                     ]
                   }
@@ -756,21 +816,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "responses": [
                           {
                             "response": "Old answer 1",
+                            "responseDate": "2023-12-05",
+                            "additionalInformation": "comment 1",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 2",
+                            "responseDate": null,
+                            "additionalInformation": "comment 2",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 3",
+                            "responseDate": "2023-11-28",
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 3"
+                            "recordedAt": "2023-12-05T12:34:56"
                           }
                         ]
                       },
@@ -781,21 +844,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "responses": [
                           {
                             "response": "Old answer 1",
+                            "responseDate": "2023-12-04",
+                            "additionalInformation": "comment 1",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 2",
+                            "responseDate": null,
+                            "additionalInformation": "comment 2",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 3",
+                            "responseDate": "2023-11-27",
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 3"
+                            "recordedAt": "2023-12-05T12:34:56"
                           }
                         ]
                       },
@@ -806,21 +872,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "responses": [
                           {
                             "response": "Old answer 1",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 2",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-05T12:34:56"
                           },
                           {
                             "response": "Old answer 3",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-05T12:34:56",
-                            "additionalInformation": "comment 3"
+                            "recordedAt": "2023-12-05T12:34:56"
                           }
                         ]
                       }
@@ -973,6 +1042,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     10,
                     1,
                     "John",
+                    now.toLocalDate().minusDays(2),
                     "comment 1",
                     createDateTime = now,
                     createdBy = reportingStaff.username,
@@ -982,6 +1052,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     11,
                     2,
                     "Trevor",
+                    null,
                     "comment 2",
                     createDateTime = now,
                     createdBy = reportingStaff.username,
@@ -991,7 +1062,8 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     12,
                     3,
                     "Maybe someone else?",
-                    "comment 3",
+                    now.toLocalDate().minusDays(3),
+                    null,
                     createDateTime = now,
                     createdBy = reportingStaff.username,
                     recordingStaff = reportingStaff,
@@ -1009,6 +1081,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     13,
                     1,
                     "Cell",
+                    now.toLocalDate().minusDays(1),
                     "comment 1",
                     createDateTime = now,
                     createdBy = reportingStaff.username,
@@ -1018,6 +1091,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     14,
                     2,
                     "Landing",
+                    null,
                     "comment 2",
                     createDateTime = now,
                     createdBy = reportingStaff.username,
@@ -1027,7 +1101,18 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     15,
                     3,
                     "Kitchen",
-                    "comment 3",
+                    now.toLocalDate().minusDays(10),
+                    null,
+                    createDateTime = now,
+                    createdBy = reportingStaff.username,
+                    recordingStaff = reportingStaff,
+                  ),
+                  NomisResponse(
+                    16,
+                    4,
+                    "Exercise area",
+                    null,
+                    null,
                     createDateTime = now,
                     createdBy = reportingStaff.username,
                     recordingStaff = reportingStaff,
@@ -1050,8 +1135,9 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     1,
                     "Old question 1",
                     listOf(
-                      NomisHistoryResponse(1, 1, "Old answer 1", "comment 1", reportingStaff),
-                      NomisHistoryResponse(2, 2, "Old answer 2", "comment 2", reportingStaff),
+                      NomisHistoryResponse(1, 1, "Old answer 1", now.toLocalDate(), "comment 1", reportingStaff),
+                      NomisHistoryResponse(2, 2, "Old answer 2", null, "comment 2", reportingStaff),
+                      NomisHistoryResponse(3, 3, "Old answer 3", now.toLocalDate().minusDays(7), null, reportingStaff),
                     ),
                   ),
                   NomisHistoryQuestion(
@@ -1059,8 +1145,9 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     2,
                     "Old question 2",
                     listOf(
-                      NomisHistoryResponse(4, 1, "Old answer 1", "comment 1", reportingStaff),
-                      NomisHistoryResponse(5, 2, "Old answer 2", "comment 2", reportingStaff),
+                      NomisHistoryResponse(4, 1, "Old answer 4", now.toLocalDate().minusDays(1), "comment 1", reportingStaff),
+                      NomisHistoryResponse(5, 2, "Old answer 5", null, "comment 2", reportingStaff),
+                      NomisHistoryResponse(6, 3, "Old answer 6", now.toLocalDate().minusDays(8), null, reportingStaff),
                     ),
                   ),
                 ),
@@ -1079,8 +1166,8 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     1,
                     "Old old question 1",
                     listOf(
-                      NomisHistoryResponse(12, 1, "Old old answer 1", "comment 1", reportingStaff),
-                      NomisHistoryResponse(22, 2, "Old old answer 2", "comment 2", reportingStaff),
+                      NomisHistoryResponse(12, 1, "Old old answer 1", null, null, reportingStaff),
+                      NomisHistoryResponse(22, 2, "Old old answer 2", null, null, reportingStaff),
                     ),
                   ),
                   NomisHistoryQuestion(
@@ -1088,8 +1175,8 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     2,
                     "Old old question 2",
                     listOf(
-                      NomisHistoryResponse(44, 1, "Old old answer 1", "comment 1", reportingStaff),
-                      NomisHistoryResponse(55, 2, "Old old answer 2", "comment 2", reportingStaff),
+                      NomisHistoryResponse(44, 1, "Old old answer 1", null, null, reportingStaff),
+                      NomisHistoryResponse(55, 2, "Old old answer 2", null, null, reportingStaff),
                     ),
                   ),
                 ),
@@ -1136,21 +1223,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "responses": [
                       {
                         "response": "John",
+                        "responseDate": "2023-12-03",
+                        "additionalInformation": "comment 1",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-04T12:34:56",
-                        "additionalInformation": "comment 1"
+                        "recordedAt": "2023-12-04T12:34:56"
                       },
                       {
                         "response": "Trevor",
+                        "responseDate": null,
+                        "additionalInformation": "comment 2",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-04T12:34:56",
-                        "additionalInformation": "comment 2"
+                        "recordedAt": "2023-12-04T12:34:56"
                       },
                       {
                         "response": "Maybe someone else?",
+                        "responseDate": "2023-12-02",
+                        "additionalInformation": null,
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-04T12:34:56",
-                        "additionalInformation": "comment 3"
+                        "recordedAt": "2023-12-04T12:34:56"
                       }
                     ],
                     "additionalInformation": null
@@ -1161,21 +1251,31 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "responses": [
                       {
                         "response": "Cell",
+                        "responseDate": "2023-12-04",
+                        "additionalInformation": "comment 1",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-04T12:34:56",
-                        "additionalInformation": "comment 1"
+                        "recordedAt": "2023-12-04T12:34:56"
                       },
                       {
                         "response": "Landing",
+                        "responseDate": null,
+                        "additionalInformation": "comment 2",
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-04T12:34:56",
-                        "additionalInformation": "comment 2"
+                        "recordedAt": "2023-12-04T12:34:56"
                       },
                       {
                         "response": "Kitchen",
+                        "responseDate": "2023-11-25",
+                        "additionalInformation": null,
                         "recordedBy": "user2",
-                        "recordedAt": "2023-12-04T12:34:56",
-                        "additionalInformation": "comment 3"
+                        "recordedAt": "2023-12-04T12:34:56"
+                      },
+                      {
+                        "response": "Exercise area",
+                        "responseDate": null,
+                        "additionalInformation": null,
+                        "recordedBy": "user2",
+                        "recordedAt": "2023-12-04T12:34:56"
                       }
                     ],
                     "additionalInformation": null
@@ -1193,15 +1293,24 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "responses": [
                           {
                             "response": "Old answer 1",
+                            "responseDate": "2023-12-05",
+                            "additionalInformation": "comment 1",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-04T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
                             "response": "Old answer 2",
+                            "responseDate": null,
+                            "additionalInformation": "comment 2",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-04T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-04T12:34:56"
+                          },
+                          {
+                            "response": "Old answer 3",
+                            "responseDate": "2023-11-28",
+                            "additionalInformation": null,
+                            "recordedBy": "user2",
+                            "recordedAt": "2023-12-04T12:34:56"
                           }
                         ],
                         "additionalInformation": null
@@ -1211,16 +1320,25 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "question": "Old question 2",
                         "responses": [
                           {
-                            "response": "Old answer 1",
+                            "response": "Old answer 4",
+                            "responseDate": "2023-12-04",
+                            "additionalInformation": "comment 1",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-04T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
-                            "response": "Old answer 2",
+                            "response": "Old answer 5",
+                            "responseDate": null,
+                            "additionalInformation": "comment 2",
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-04T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-04T12:34:56"
+                          },
+                          {
+                            "response": "Old answer 6",
+                            "responseDate": "2023-11-27",
+                            "additionalInformation": null,
+                            "recordedBy": "user2",
+                            "recordedAt": "2023-12-04T12:34:56"
                           }
                         ],
                         "additionalInformation": null
@@ -1238,15 +1356,17 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "responses": [
                           {
                             "response": "Old old answer 1",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-04T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
                             "response": "Old old answer 2",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-04T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-04T12:34:56"
                           }
                         ],
                         "additionalInformation": null
@@ -1257,15 +1377,17 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "responses": [
                           {
                             "response": "Old old answer 1",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-04T12:34:56",
-                            "additionalInformation": "comment 1"
+                            "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
                             "response": "Old old answer 2",
+                            "responseDate": null,
+                            "additionalInformation": null,
                             "recordedBy": "user2",
-                            "recordedAt": "2023-12-04T12:34:56",
-                            "additionalInformation": "comment 2"
+                            "recordedAt": "2023-12-04T12:34:56"
                           }
                         ],
                         "additionalInformation": null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -1613,12 +1613,14 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                   "responses": [
                     {
                       "response": "Response #1",
+                      "responseDate": "2023-12-04",
                       "additionalInformation": "Prose #1",
                       "recordedBy": "some-user",
                       "recordedAt": "2023-12-05T12:31:56"
                     },
                     {
                       "response": "Response #2",
+                      "responseDate": "2023-12-03",
                       "additionalInformation": "Prose #2",
                       "recordedBy": "some-user",
                       "recordedAt": "2023-12-05T12:31:56"
@@ -1632,12 +1634,14 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                   "responses": [
                     {
                       "response": "Response #1",
+                      "responseDate": "2023-12-04",
                       "additionalInformation": "Prose #1",
                       "recordedBy": "some-user",
                       "recordedAt": "2023-12-05T12:31:56"
                     },
                     {
                       "response": "Response #2",
+                      "responseDate": "2023-12-03",
                       "additionalInformation": "Prose #2",
                       "recordedBy": "some-user",
                       "recordedAt": "2023-12-05T12:31:56"
@@ -1703,12 +1707,14 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                       "responses": [
                         {
                           "response": "Response #1",
+                          "responseDate": "2023-12-04",
                           "additionalInformation": "Prose #1",
                           "recordedBy": "some-user",
                           "recordedAt": "2023-12-05T12:31:56"
                         },
                         {
                           "response": "Response #2",
+                          "responseDate": "2023-12-03",
                           "additionalInformation": "Prose #2",
                           "recordedBy": "some-user",
                           "recordedAt": "2023-12-05T12:31:56"
@@ -1722,12 +1728,14 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                       "responses": [
                         {
                           "response": "Response #1",
+                          "responseDate": "2023-12-04",
                           "additionalInformation": "Prose #1",
                           "recordedBy": "some-user",
                           "recordedAt": "2023-12-05T12:31:56"
                         },
                         {
                           "response": "Response #2",
+                          "responseDate": "2023-12-03",
                           "additionalInformation": "Prose #2",
                           "recordedBy": "some-user",
                           "recordedAt": "2023-12-05T12:31:56"
@@ -1801,6 +1809,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                       "responses": [
                         {
                           "response": "Historical response #1-1",
+                          "responseDate": "2023-12-04",
                           "additionalInformation": "Prose #1 in history #1",
                           "recordedBy": "some-user",
                           "recordedAt": "2023-12-05T12:31:56"
@@ -1821,6 +1830,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                       "responses": [
                         {
                           "response": "Response #1",
+                          "responseDate": "2023-12-04",
                           "additionalInformation": "Prose #1",
                           "recordedBy": "some-user",
                           "recordedAt": "2023-12-05T12:31:56"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
@@ -267,9 +267,10 @@ class NomisSyncServiceTest {
     assertThat(question.responses).hasSize(1)
     val response = question.responses[0]
     assertThat(response.response).isEqualTo("Razor")
+    assertThat(response.responseDate).isNull()
+    assertThat(response.additionalInformation).isNull()
     assertThat(response.recordedBy).isEqualTo(reportedBy)
     assertThat(response.recordedAt).isEqualTo(now)
-    assertThat(response.additionalInformation).isNull()
 
     assertThat(report.prisonersInvolved).hasSize(1)
     val prisonerInvolved = report.prisonersInvolved[0]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
@@ -181,7 +181,7 @@ class NomisSyncServiceTest {
 
   init {
     sampleReport.addQuestion("QID-000000000042", "What implement was used?")
-      .addResponse("Razor", null, reportedBy, now)
+      .addResponse("Razor", null, null, reportedBy, now)
     sampleReport.addStaffInvolved(StaffRole.PRESENT_AT_SCENE, "user3", "Found offender in cell")
     sampleReport.addPrisonerInvolved(
       "A1234AA",

--- a/src/test/resources/entity-mapping/sample-report-with-details.json
+++ b/src/test/resources/entity-mapping/sample-report-with-details.json
@@ -30,15 +30,17 @@
       "responses": [
         {
           "response": "Response #1",
+          "responseDate": "2023-12-04",
+          "additionalInformation": "Prose #1",
           "recordedBy": "some-user",
-          "recordedAt": "2023-12-05T12:34:56",
-          "additionalInformation": "Prose #1"
+          "recordedAt": "2023-12-05T12:34:56"
         },
         {
           "response": "Response #2",
+          "responseDate": "2023-12-03",
+          "additionalInformation": "Prose #2",
           "recordedBy": "some-user",
-          "recordedAt": "2023-12-05T12:34:56",
-          "additionalInformation": "Prose #2"
+          "recordedAt": "2023-12-05T12:34:56"
         }
       ],
       "additionalInformation": "Explanation #1"
@@ -49,15 +51,17 @@
       "responses": [
         {
           "response": "Response #1",
+          "responseDate": "2023-12-04",
+          "additionalInformation": "Prose #1",
           "recordedBy": "some-user",
-          "recordedAt": "2023-12-05T12:34:56",
-          "additionalInformation": "Prose #1"
+          "recordedAt": "2023-12-05T12:34:56"
         },
         {
           "response": "Response #2",
+          "responseDate": "2023-12-03",
+          "additionalInformation": "Prose #2",
           "recordedBy": "some-user",
-          "recordedAt": "2023-12-05T12:34:56",
-          "additionalInformation": "Prose #2"
+          "recordedAt": "2023-12-05T12:34:56"
         }
       ],
       "additionalInformation": "Explanation #2"
@@ -68,15 +72,17 @@
       "responses": [
         {
           "response": "Response #1",
+          "responseDate": "2023-12-04",
+          "additionalInformation": "Prose #1",
           "recordedBy": "some-user",
-          "recordedAt": "2023-12-05T12:34:56",
-          "additionalInformation": "Prose #1"
+          "recordedAt": "2023-12-05T12:34:56"
         },
         {
           "response": "Response #2",
+          "responseDate": "2023-12-03",
+          "additionalInformation": "Prose #2",
           "recordedBy": "some-user",
-          "recordedAt": "2023-12-05T12:34:56",
-          "additionalInformation": "Prose #2"
+          "recordedAt": "2023-12-05T12:34:56"
         }
       ],
       "additionalInformation": "Explanation #3"
@@ -94,15 +100,17 @@
           "responses": [
             {
               "response": "Historical response #1-1",
+              "responseDate": "2023-12-04",
+              "additionalInformation": "Prose #1 in history #1",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #1 in history #1"
+              "recordedAt": "2023-12-05T12:34:56"
             },
             {
               "response": "Historical response #1-2",
+              "responseDate": "2023-12-03",
+              "additionalInformation": "Prose #2 in history #1",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #2 in history #1"
+              "recordedAt": "2023-12-05T12:34:56"
             }
           ],
           "additionalInformation": "Explanation #1 in history #1"
@@ -113,15 +121,17 @@
           "responses": [
             {
               "response": "Historical response #1-1",
+              "responseDate": "2023-12-04",
+              "additionalInformation": "Prose #1 in history #1",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #1 in history #1"
+              "recordedAt": "2023-12-05T12:34:56"
             },
             {
               "response": "Historical response #1-2",
+              "responseDate": "2023-12-03",
+              "additionalInformation": "Prose #2 in history #1",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #2 in history #1"
+              "recordedAt": "2023-12-05T12:34:56"
             }
           ],
           "additionalInformation": "Explanation #2 in history #1"
@@ -132,15 +142,17 @@
           "responses": [
             {
               "response": "Historical response #1-1",
+              "responseDate": "2023-12-04",
+              "additionalInformation": "Prose #1 in history #1",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #1 in history #1"
+              "recordedAt": "2023-12-05T12:34:56"
             },
             {
               "response": "Historical response #1-2",
+              "responseDate": "2023-12-03",
+              "additionalInformation": "Prose #2 in history #1",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #2 in history #1"
+              "recordedAt": "2023-12-05T12:34:56"
             }
           ],
           "additionalInformation": "Explanation #3 in history #1"
@@ -158,15 +170,17 @@
           "responses": [
             {
               "response": "Historical response #2-1",
+              "responseDate": "2023-12-04",
+              "additionalInformation": "Prose #1 in history #2",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #1 in history #2"
+              "recordedAt": "2023-12-05T12:34:56"
             },
             {
               "response": "Historical response #2-2",
+              "responseDate": "2023-12-03",
+              "additionalInformation": "Prose #2 in history #2",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #2 in history #2"
+              "recordedAt": "2023-12-05T12:34:56"
             }
           ],
           "additionalInformation": "Explanation #1 in history #2"
@@ -177,15 +191,17 @@
           "responses": [
             {
               "response": "Historical response #2-1",
+              "responseDate": "2023-12-04",
+              "additionalInformation": "Prose #1 in history #2",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #1 in history #2"
+              "recordedAt": "2023-12-05T12:34:56"
             },
             {
               "response": "Historical response #2-2",
+              "responseDate": "2023-12-03",
+              "additionalInformation": "Prose #2 in history #2",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #2 in history #2"
+              "recordedAt": "2023-12-05T12:34:56"
             }
           ],
           "additionalInformation": "Explanation #2 in history #2"
@@ -196,15 +212,17 @@
           "responses": [
             {
               "response": "Historical response #2-1",
+              "responseDate": "2023-12-04",
+              "additionalInformation": "Prose #1 in history #2",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #1 in history #2"
+              "recordedAt": "2023-12-05T12:34:56"
             },
             {
               "response": "Historical response #2-2",
+              "responseDate": "2023-12-03",
+              "additionalInformation": "Prose #2 in history #2",
               "recordedBy": "some-user",
-              "recordedAt": "2023-12-05T12:34:56",
-              "additionalInformation": "Prose #2 in history #2"
+              "recordedAt": "2023-12-05T12:34:56"
             }
           ],
           "additionalInformation": "Explanation #3 in history #2"

--- a/src/test/resources/questions-with-responses/add-request-empty-question.json
+++ b/src/test/resources/questions-with-responses/add-request-empty-question.json
@@ -9,6 +9,7 @@
     },
     {
       "response": "Mobile phone",
+      "responseDate": "2023-12-04",
       "additionalInformation": "Not a smartphone"
     }
   ]

--- a/src/test/resources/questions-with-responses/add-request-empty-response.json
+++ b/src/test/resources/questions-with-responses/add-request-empty-response.json
@@ -5,6 +5,7 @@
   "responses": [
     {
       "response": "Note with phone number",
+      "responseDate": "2023-12-04",
       "additionalInformation": "020 1111 2222"
     },
     {

--- a/src/test/resources/questions-with-responses/add-request-with-responses-and-null-fields.json
+++ b/src/test/resources/questions-with-responses/add-request-with-responses-and-null-fields.json
@@ -9,6 +9,10 @@
     {
       "response": "Mobile phone",
       "additionalInformation": null
+    },
+    {
+      "response": "Chewing gum",
+      "responseDate": null
     }
   ]
 }

--- a/src/test/resources/questions-with-responses/add-request-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-request-with-responses.json
@@ -10,6 +10,10 @@
     {
       "response": "Mobile phone",
       "additionalInformation": "Not a smartphone"
+    },
+    {
+      "response": "Note with date",
+      "responseDate": "2023-11-30"
     }
   ]
 }

--- a/src/test/resources/questions-with-responses/add-response-with-responses-and-null-fields.json
+++ b/src/test/resources/questions-with-responses/add-response-with-responses-and-null-fields.json
@@ -5,15 +5,17 @@
     "responses": [
       {
         "response": "Response #1",
+        "responseDate": "2023-12-04",
+        "additionalInformation": "Prose #1",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #1"
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Response #2",
+        "responseDate": "2023-12-03",
+        "additionalInformation": "Prose #2",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #2"
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ],
     "additionalInformation": "Explanation #1"
@@ -24,15 +26,17 @@
     "responses": [
       {
         "response": "Response #1",
+        "responseDate": "2023-12-04",
+        "additionalInformation": "Prose #1",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #1"
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Response #2",
+        "responseDate": "2023-12-03",
+        "additionalInformation": "Prose #2",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #2"
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ],
     "additionalInformation": "Explanation #2"
@@ -44,15 +48,24 @@
     "responses": [
       {
         "response": "Note with phone number",
+        "responseDate": null,
+        "additionalInformation": null,
         "recordedBy": "request-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": null
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Mobile phone",
+        "responseDate": null,
+        "additionalInformation": null,
         "recordedBy": "request-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": null
+        "recordedAt": "2023-12-05T12:34:56"
+      },
+      {
+        "response": "Chewing gum",
+        "responseDate": null,
+        "additionalInformation": null,
+        "recordedBy": "request-user",
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ]
   }

--- a/src/test/resources/questions-with-responses/add-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-with-responses.json
@@ -5,15 +5,17 @@
     "responses": [
       {
         "response": "Response #1",
+        "responseDate": "2023-12-04",
+        "additionalInformation": "Prose #1",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #1"
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Response #2",
+        "responseDate": "2023-12-03",
+        "additionalInformation": "Prose #2",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #2"
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ],
     "additionalInformation": "Explanation #1"
@@ -24,15 +26,17 @@
     "responses": [
       {
         "response": "Response #1",
+        "responseDate": "2023-12-04",
+        "additionalInformation": "Prose #1",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #1"
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Response #2",
+        "responseDate": "2023-12-03",
+        "additionalInformation": "Prose #2",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #2"
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ],
     "additionalInformation": "Explanation #2"
@@ -44,15 +48,24 @@
     "responses": [
       {
         "response": "Note with phone number",
+        "responseDate": null,
+        "additionalInformation": "020 1111 2222",
         "recordedBy": "request-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "020 1111 2222"
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Mobile phone",
+        "responseDate": null,
+        "additionalInformation": "Not a smartphone",
         "recordedBy": "request-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Not a smartphone"
+        "recordedAt": "2023-12-05T12:34:56"
+      },
+      {
+        "response": "Note with date",
+        "responseDate": "2023-11-30",
+        "additionalInformation": null,
+        "recordedBy": "request-user",
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ]
   }

--- a/src/test/resources/questions-with-responses/add-response-without-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-without-responses.json
@@ -6,15 +6,24 @@
     "responses": [
       {
         "response": "Note with phone number",
+        "responseDate": null,
+        "additionalInformation": "020 1111 2222",
         "recordedBy": "request-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "020 1111 2222"
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Mobile phone",
+        "responseDate": null,
+        "additionalInformation": "Not a smartphone",
         "recordedBy": "request-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Not a smartphone"
+        "recordedAt": "2023-12-05T12:34:56"
+      },
+      {
+        "response": "Note with date",
+        "responseDate": "2023-11-30",
+        "additionalInformation": null,
+        "recordedBy": "request-user",
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ]
   }

--- a/src/test/resources/questions-with-responses/delete-response.json
+++ b/src/test/resources/questions-with-responses/delete-response.json
@@ -5,15 +5,17 @@
     "responses": [
       {
         "response": "Response #1",
+        "responseDate": "2023-12-04",
+        "additionalInformation": "Prose #1",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #1"
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Response #2",
+        "responseDate": "2023-12-03",
+        "additionalInformation": "Prose #2",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #2"
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ],
     "additionalInformation": "Explanation #1"

--- a/src/test/resources/questions-with-responses/list-response-with-several.json
+++ b/src/test/resources/questions-with-responses/list-response-with-several.json
@@ -5,15 +5,17 @@
     "responses": [
       {
         "response": "Response #1",
+        "responseDate": "2023-12-04",
+        "additionalInformation": "Prose #1",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #1"
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Response #2",
+        "responseDate": "2023-12-03",
+        "additionalInformation": "Prose #2",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #2"
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ],
     "additionalInformation": "Explanation #1"
@@ -24,15 +26,17 @@
     "responses": [
       {
         "response": "Response #1",
+        "responseDate": "2023-12-04",
+        "additionalInformation": "Prose #1",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #1"
+        "recordedAt": "2023-12-05T12:34:56"
       },
       {
         "response": "Response #2",
+        "responseDate": "2023-12-03",
+        "additionalInformation": "Prose #2",
         "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56",
-        "additionalInformation": "Prose #2"
+        "recordedAt": "2023-12-05T12:34:56"
       }
     ],
     "additionalInformation": "Explanation #2"


### PR DESCRIPTION
In NOMIS, some responses ask the user to enter a date alongside. This was missed and previously only the comment / additional information field was being handled.

In future, the DPS version of incident reporting may or may not ask users to enter dates, but historic information needs to still be preserved.

*NB: Will require databases to be trashed when deploying*