### PR TITLE
IR-402: Added indexes on FKs columns

### DIFF
--- a/src/main/resources/db/migration/V1_2__add_fks_indexes.sql
+++ b/src/main/resources/db/migration/V1_2__add_fks_indexes.sql
@@ -1,0 +1,15 @@
+CREATE INDEX report_event_id_fk_idx ON report(event_id);
+
+CREATE INDEX question_report_id_fk_idx ON question(report_id);
+CREATE INDEX response_question_id_fk_idx ON response(question_id);
+
+CREATE INDEX history_report_id_fk_idx ON history(report_id);
+CREATE INDEX historical_question_history_id_fk_idx ON historical_question(history_id);
+CREATE INDEX historical_response_historical_question_id_fk_idx ON historical_response(historical_question_id);
+
+CREATE INDEX prisoner_involvement_report_id_fk_idx ON prisoner_involvement(report_id);
+CREATE INDEX staff_involvement_report_id_fk_idx ON staff_involvement(report_id);
+
+CREATE INDEX correction_request_report_id_fk_idx ON correction_request(report_id);
+
+CREATE INDEX status_history_report_id_fk_idx ON status_history(report_id);


### PR DESCRIPTION
`dev` environment was very slow, after investigation I realised tables didn't have indexes on Foreign Keys (FK) columns.

Manually add these indexes resolved these performances issues. (I imagine the bulk of the problem was caused by the ~10M records in the `question`/`response` DB tables)

This PR properly add these indexes (so that they're also added to `preprod`/`prod`)