### PR TITLE
IR-381: Increase report sequence to 10,000,000

### DIFF
--- a/src/main/resources/db/migration/V1_4__increase_report_sequence.sql
+++ b/src/main/resources/db/migration/V1_4__increase_report_sequence.sql
@@ -1,0 +1,2 @@
+-- Sequence starts at 10,000,000
+SELECT setval('report_sequence', 10000000);


### PR DESCRIPTION
Previously this was 1,000,000 but this is too low.

There are ~2 million reports. Recent report's reference numbers are already in the ~4.5 millions.

Starting at 1,000,000 can lead to clashes with NOMIS reference numbers.