### PR TITLE
IR-421: Send alerts to our dev channel

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,7 +16,7 @@ generic-service:
     API_BASE_URL_OAUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-incident-reporting-dev
   businessHoursOnly: true
   rdsAlertsDatabases:
     cloud-platform-357b6fd216e4b0ae: incident-reporting-api

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,7 +14,7 @@ generic-service:
     API_BASE_URL_OAUTH: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-incident-reporting-preprod
   businessHoursOnly: true
   rdsAlertsDatabases:
     cloud-platform-aeef80d0d303f28e: incident-reporting-api

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -20,7 +20,7 @@ generic-service:
         DB_HOST_PREPROD: "rds_instance_address"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service
+  alertSeverity: hmpps-incident-reporting-prod
   rdsAlertsDatabases:
     cloud-platform-6da4d16fce197ed0: incident-reporting-api
   sqsAlertsQueueNames:


### PR DESCRIPTION
Use `alertSeverity` provided by CP team.
These would send alerts to the `#incident-reporting-service-dev` Slack channel.