### PR TITLE
Label types with OpenAPI attributes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/CorrectionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/CorrectionRequest.kt
@@ -5,15 +5,15 @@ import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.CorrectionReason
 import java.time.LocalDateTime
 
-@Schema(description = "Request to make a correction to incident report")
+@Schema(description = "Request to make a correction to incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class CorrectionRequest(
-  @Schema(description = "Why the correction is needed", required = true)
+  @Schema(description = "Why the correction is needed")
   val reason: CorrectionReason,
-  @Schema(description = "The changes being requested", required = true)
+  @Schema(description = "The changes being requested")
   val descriptionOfChange: String,
-  @Schema(description = "Member of staff requesting changed", required = true)
+  @Schema(description = "Member of staff requesting changed")
   val correctionRequestedBy: String,
-  @Schema(description = "When the changes were requested", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the changes were requested", example = "2024-04-29T12:34:56.789012")
   val correctionRequestedAt: LocalDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Event.kt
@@ -5,27 +5,27 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 import java.util.UUID
 
-@Schema(description = "Event linking multiple incident reports")
+@Schema(description = "Event linking multiple incident reports", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 open class Event(
-  @Schema(description = "The internal ID of this event", required = true)
+  @Schema(description = "The internal ID of this event")
   val id: UUID,
-  @Schema(description = "The human-readable identifier of this event", required = true)
+  @Schema(description = "The human-readable identifier of this event")
   val eventReference: String,
-  @Schema(description = "When the incident took place", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the incident took place", example = "2024-04-29T12:34:56.789012")
   val eventDateAndTime: LocalDateTime,
-  @Schema(description = "The NOMIS id of the prison where incident took place", required = true, example = "MDI")
+  @Schema(description = "The NOMIS id of the prison where incident took place", example = "MDI")
   val prisonId: String,
 
-  @Schema(description = "Brief title describing the event", required = true)
+  @Schema(description = "Brief title describing the event")
   val title: String,
-  @Schema(description = "Longer summary of the event", required = true)
+  @Schema(description = "Longer summary of the event")
   val description: String,
 
-  @Schema(description = "When the event was first created", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the event was first created", example = "2024-04-29T12:34:56.789012")
   val createdAt: LocalDateTime,
-  @Schema(description = "When the event was last changed", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the event was last changed", example = "2024-04-29T12:34:56.789012")
   val modifiedAt: LocalDateTime,
-  @Schema(description = "Username of the person who last changed this event", required = true)
+  @Schema(description = "Username of the person who last changed this event")
   val modifiedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/EventWithBasicReports.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/EventWithBasicReports.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 import java.util.UUID
 
-@Schema(description = "Event linking multiple incident reports (including key report information)")
+@Schema(description = "Event linking multiple incident reports (including key report information)", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 class EventWithBasicReports(
   id: UUID,
@@ -18,7 +18,7 @@ class EventWithBasicReports(
   modifiedAt: LocalDateTime,
   modifiedBy: String,
 
-  @Schema(description = "The contained reports with key information only", required = true)
+  @Schema(description = "The contained reports with key information only")
   val reports: List<ReportBasic>,
 ) : Event(
   id = id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalQuestion.kt
@@ -3,15 +3,15 @@ package uk.gov.justice.digital.hmpps.incidentreporting.dto
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Previous question with responses making up a previous version of an incident report")
+@Schema(description = "Previous question with responses making up a previous version of an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class HistoricalQuestion(
-  @Schema(description = "The question code", required = true)
+  @Schema(description = "The question code")
   val code: String,
-  @Schema(description = "The question", required = true)
+  @Schema(description = "The question")
   val question: String,
-  @Schema(description = "The responses to this question", required = true)
+  @Schema(description = "The responses to this question")
   val responses: List<HistoricalResponse> = emptyList(),
-  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  @Schema(description = "Optional additional information", nullable = true)
   val additionalInformation: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalResponse.kt
@@ -5,18 +5,18 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-@Schema(description = "Previous response to a question making up a previous version of an incident report")
+@Schema(description = "Previous response to a question making up a previous version of an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class HistoricalResponse(
-  @Schema(description = "The response", required = true)
+  @Schema(description = "The response")
   val response: String,
-  @Schema(description = "Optional response as a date", required = false, example = "2024-04-29")
+  @Schema(description = "Optional response as a date", nullable = true, example = "2024-04-29")
   val responseDate: LocalDate? = null,
-  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  @Schema(description = "Optional additional information", nullable = true)
   val additionalInformation: String? = null,
 
-  @Schema(description = "Username of person who responded to the question", required = true)
+  @Schema(description = "Username of person who responded to the question")
   val recordedBy: String,
-  @Schema(description = "When the response was made", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the response was made", example = "2024-04-29T12:34:56.789012")
   val recordedAt: LocalDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/History.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/History.kt
@@ -6,20 +6,20 @@ import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import java.time.LocalDateTime
 
-@Schema(description = "Prior version of an incident report")
+@Schema(description = "Prior version of an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class History(
-  @Schema(description = "Previous incident report type", required = true)
+  @Schema(description = "Previous incident report type")
   val type: Type,
-  @Schema(description = "When the report type was changed", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the report type was changed", example = "2024-04-29T12:34:56.789012")
   val changedAt: LocalDateTime,
-  @Schema(description = "The member of staff who changed the report type", required = true)
+  @Schema(description = "The member of staff who changed the report type")
   val changedBy: String,
-  @Schema(description = "Previous set of question-response pairs", required = true)
+  @Schema(description = "Previous set of question-response pairs")
   val questions: List<HistoricalQuestion> = emptyList(),
 ) {
   // NB: this property can be removed once fully migrated off NOMIS and reconciliation checks are turned off
-  @get:Schema(description = "Previous NOMIS incident report type code, which may be null for newer incident types", required = false, deprecated = true)
+  @get:Schema(description = "Previous NOMIS incident report type code, which may be null for newer incident types", nullable = true, deprecated = true)
   @get:JsonProperty
   val nomisType: String?
     get() = type.nomisType

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/PrisonerInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/PrisonerInvolvement.kt
@@ -5,15 +5,15 @@ import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerOutcome
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerRole
 
-@Schema(description = "Prisoner involved in an incident")
+@Schema(description = "Prisoner involved in an incident", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class PrisonerInvolvement(
-  @Schema(description = "Prisoner’s NOMIS number", required = true)
+  @Schema(description = "Prisoner’s NOMIS number")
   val prisonerNumber: String,
-  @Schema(description = "Their role", required = true)
+  @Schema(description = "Their role")
   val prisonerRole: PrisonerRole,
-  @Schema(description = "Optional outcome of prisoner’s involvement", required = false, defaultValue = "null")
+  @Schema(description = "Optional outcome of prisoner’s involvement", nullable = true)
   val outcome: PrisonerOutcome? = null,
-  @Schema(description = "Optional comment on prisoner’s involvement", required = false, defaultValue = "null")
+  @Schema(description = "Optional comment on prisoner’s involvement", nullable = true)
   val comment: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Question.kt
@@ -3,15 +3,15 @@ package uk.gov.justice.digital.hmpps.incidentreporting.dto
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Question with responses making up an incident report")
+@Schema(description = "Question with responses making up an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class Question(
-  @Schema(description = "The question code", required = true)
+  @Schema(description = "The question code")
   val code: String,
-  @Schema(description = "The question", required = true)
+  @Schema(description = "The question")
   val question: String,
-  @Schema(description = "The responses to this question", required = true)
+  @Schema(description = "The responses to this question")
   val responses: List<Response> = emptyList(),
-  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  @Schema(description = "Optional additional information", nullable = true)
   val additionalInformation: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportBasic.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportBasic.kt
@@ -8,41 +8,41 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import java.time.LocalDateTime
 import java.util.UUID
 
-@Schema(description = "Incident report with only key information")
+@Schema(description = "Incident report with only key information", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 open class ReportBasic(
-  @Schema(description = "The internal ID of this report", required = true)
+  @Schema(description = "The internal ID of this report")
   val id: UUID,
-  @Schema(description = "The human-readable identifier of this report", required = true)
+  @Schema(description = "The human-readable identifier of this report")
   val reportReference: String,
-  @Schema(description = "Incident report type", required = true)
+  @Schema(description = "Incident report type")
   val type: Type,
-  @Schema(description = "When the incident took place", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the incident took place", example = "2024-04-29T12:34:56.789012")
   val incidentDateAndTime: LocalDateTime,
-  @Schema(description = "The NOMIS id of the prison where incident took place", required = true, example = "MDI")
+  @Schema(description = "The NOMIS id of the prison where incident took place", example = "MDI")
   val prisonId: String,
-  @Schema(description = "Brief title describing the incident", required = true)
+  @Schema(description = "Brief title describing the incident")
   val title: String,
-  @Schema(description = "Longer summary of the incident", required = true)
+  @Schema(description = "Longer summary of the incident")
   val description: String,
 
-  @Schema(description = "Username of person who created the incident report", required = true)
+  @Schema(description = "Username of person who created the incident report")
   val reportedBy: String,
-  @Schema(description = "When the incident report was created", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the incident report was created", example = "2024-04-29T12:34:56.789012")
   val reportedAt: LocalDateTime,
-  @Schema(description = "The current status of this report", required = true, example = "DRAFT")
+  @Schema(description = "The current status of this report", example = "DRAFT")
   val status: Status,
-  @Schema(description = "Optional user who this report is currently assigned to", required = true, example = "null")
+  @Schema(description = "Optional user who this report is currently assigned to", example = "null")
   val assignedTo: String?,
 
-  @Schema(description = "When the report was first created", required = true)
+  @Schema(description = "When the report was first created", example = "2024-04-29T12:34:56.789012")
   val createdAt: LocalDateTime,
-  @Schema(description = "When the report was last changed", required = true)
+  @Schema(description = "When the report was last changed", example = "2024-04-29T12:34:56.789012")
   val modifiedAt: LocalDateTime,
-  @Schema(description = "Username of the person who last changed this report", required = true)
+  @Schema(description = "Username of the person who last changed this report")
   val modifiedBy: String,
 
-  @Schema(description = "Whether the report was initially created in NOMIS as opposed to DPS", required = true, example = "false")
+  @Schema(description = "Whether the report was initially created in NOMIS as opposed to DPS", example = "false")
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   val createdInNomis: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import java.time.LocalDateTime
 import java.util.UUID
 
-@Schema(description = "Incident report with all related information")
+@Schema(description = "Incident report with all related information", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 class ReportWithDetails(
   id: UUID,
@@ -27,21 +27,21 @@ class ReportWithDetails(
   modifiedBy: String,
   createdInNomis: Boolean,
 
-  @Schema(description = "Event linking multiple incident reports together", required = true)
+  @Schema(description = "Event linking multiple incident reports together")
   val event: Event,
 
-  @Schema(description = "The question-response pairs that make up this report", required = true)
+  @Schema(description = "The question-response pairs that make up this report")
   val questions: List<Question>,
-  @Schema(description = "Prior versions of this report, created when the report type changes", required = true)
+  @Schema(description = "Prior versions of this report, created when the report type changes")
   val history: List<History>,
-  @Schema(description = "Previous statuses the incident report transitioned to", required = true)
+  @Schema(description = "Previous statuses the incident report transitioned to")
   val historyOfStatuses: List<StatusHistory>,
 
-  @Schema(description = "Which members of staff were involved?", required = true)
+  @Schema(description = "Which members of staff were involved?")
   val staffInvolved: List<StaffInvolvement>,
-  @Schema(description = "Which prisoners were involved?", required = true)
+  @Schema(description = "Which prisoners were involved?")
   val prisonersInvolved: List<PrisonerInvolvement>,
-  @Schema(description = "The corrections that were requested of this report", required = true)
+  @Schema(description = "The corrections that were requested of this report")
   val correctionRequests: List<CorrectionRequest>,
 ) : ReportBasic(
   id = id,
@@ -61,7 +61,7 @@ class ReportWithDetails(
   createdInNomis = createdInNomis,
 ) {
   // NB: this property can be removed once fully migrated off NOMIS and reconciliation checks are turned off
-  @get:Schema(description = "NOMIS incident report type code, which may be null for newer incident types", required = false, deprecated = true)
+  @get:Schema(description = "NOMIS incident report type code, which may be null for newer incident types", nullable = true, deprecated = true)
   @get:JsonProperty
   val nomisType: String?
     get() = type.nomisType

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Response.kt
@@ -5,18 +5,18 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-@Schema(description = "Response to a question making up an incident report")
+@Schema(description = "Response to a question making up an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class Response(
-  @Schema(description = "The response", required = true)
+  @Schema(description = "The response")
   val response: String,
-  @Schema(description = "Optional response as a date", required = false, example = "2024-04-29")
+  @Schema(description = "Optional response as a date", nullable = true, example = "2024-04-29")
   val responseDate: LocalDate? = null,
-  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  @Schema(description = "Optional additional information", nullable = true, defaultValue = "null")
   val additionalInformation: String? = null,
 
-  @Schema(description = "Username of person who responded to the question", required = true)
+  @Schema(description = "Username of person who responded to the question")
   val recordedBy: String,
-  @Schema(description = "When the response was made", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the response was made", example = "2024-04-29T12:34:56.789012")
   val recordedAt: LocalDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/StaffInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/StaffInvolvement.kt
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 
-@Schema(description = "Member of staff involved in an incident")
+@Schema(description = "Member of staff involved in an incident", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class StaffInvolvement(
-  @Schema(description = "Username", required = true)
+  @Schema(description = "Username")
   val staffUsername: String,
-  @Schema(description = "Their role", required = true)
+  @Schema(description = "Their role")
   val staffRole: StaffRole,
-  @Schema(description = "Optional comment on staff member involvement", required = false, defaultValue = "null")
+  @Schema(description = "Optional comment on staff member involvement", nullable = true)
   val comment: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/StatusHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/StatusHistory.kt
@@ -5,13 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import java.time.LocalDateTime
 
-@Schema(description = "Previous statuses an incident report transitioned to")
+@Schema(description = "Previous statuses an incident report transitioned to", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class StatusHistory(
-  @Schema(description = "Previous current status of an incident report", required = true)
+  @Schema(description = "Previous current status of an incident report")
   val status: Status,
-  @Schema(description = "When the report status was changed", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the report status was changed", example = "2024-04-29T12:34:56.789012")
   val changedAt: LocalDateTime,
-  @Schema(description = "The member of staff who changed the report status", required = true)
+  @Schema(description = "The member of staff who changed the report status")
   val changedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddCorrectionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddCorrectionRequest.kt
@@ -4,11 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.CorrectionReason
 
-@Schema(description = "Add a correction request to an incident report")
+@Schema(description = "Add a correction request to an incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class AddCorrectionRequest(
-  @Schema(description = "Why the correction is needed", required = true)
+  @Schema(description = "Why the correction is needed", requiredMode = Schema.RequiredMode.REQUIRED)
   val reason: CorrectionReason,
-  @Schema(description = "The changes being requested", required = true, minLength = 1)
+  @Schema(description = "The changes being requested", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
   @field:Size(min = 1)
   val descriptionOfChange: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddPrisonerInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddPrisonerInvolvement.kt
@@ -5,15 +5,15 @@ import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerOutcome
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerRole
 
-@Schema(description = "Add an involved prisoner to an incident report")
+@Schema(description = "Add an involved prisoner to an incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class AddPrisonerInvolvement(
-  @Schema(description = "Prisoner’s NOMIS number", required = true, minLength = 7, maxLength = 10)
+  @Schema(description = "Prisoner’s NOMIS number", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 7, maxLength = 10)
   @field:Size(min = 7, max = 10)
   val prisonerNumber: String,
-  @Schema(description = "Their role", required = true)
+  @Schema(description = "Their role", requiredMode = Schema.RequiredMode.REQUIRED)
   val prisonerRole: PrisonerRole,
-  @Schema(description = "Optional outcome of prisoner’s involvement", required = false, defaultValue = "null")
+  @Schema(description = "Optional outcome of prisoner’s involvement", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val outcome: PrisonerOutcome? = null,
-  @Schema(description = "Optional comment on prisoner’s involvement", required = false, defaultValue = "null")
+  @Schema(description = "Optional comment on prisoner’s involvement", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val comment: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddQuestionWithResponses.kt
@@ -5,28 +5,29 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 import java.time.LocalDate
 
-@Schema(description = "Payload to add question with responses to an incident report")
+@Schema(description = "Payload to add question with responses to an incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class AddQuestionWithResponses(
-  @Schema(description = "The question code", required = true, minLength = 1, maxLength = 60)
+  @Schema(description = "The question code", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 60)
   @field:Size(min = 1, max = 60)
   val code: String,
-  @Schema(description = "The question", required = true, minLength = 1)
+  @Schema(description = "The question", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
   @field:Size(min = 1)
   val question: String,
-  @Schema(description = "The responses to this question", required = true, minLength = 1)
+  @Schema(description = "The responses to this question", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
   @field:Valid
   @field:Size(min = 1)
   val responses: List<AddQuestionResponse>,
-  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  @Schema(description = "Optional additional information", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val additionalInformation: String? = null,
 )
 
+@Schema(description = "A response to a question", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class AddQuestionResponse(
-  @Schema(description = "The response", required = true, minLength = 1)
+  @Schema(description = "The response", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
   @field:Size(min = 1)
   val response: String,
-  @Schema(description = "Optional response as a date", required = false, example = "2024-04-29")
+  @Schema(description = "Optional response as a date", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null", example = "2024-04-29")
   val responseDate: LocalDate? = null,
-  @Schema(description = "Optional additional information", required = false, defaultValue = "null")
+  @Schema(description = "Optional additional information", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val additionalInformation: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddStaffInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddStaffInvolvement.kt
@@ -4,13 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 
-@Schema(description = "Add an involved member of staff to an incident report")
+@Schema(description = "Add an involved member of staff to an incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class AddStaffInvolvement(
-  @Schema(description = "Username", required = true, minLength = 3, maxLength = 120)
+  @Schema(description = "Username", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 3, maxLength = 120)
   @field:Size(min = 3, max = 120)
   val staffUsername: String,
-  @Schema(description = "Their role", required = true)
+  @Schema(description = "Their role", requiredMode = Schema.RequiredMode.REQUIRED)
   val staffRole: StaffRole,
-  @Schema(description = "Optional comment on staff member involvement", required = false, defaultValue = "null")
+  @Schema(description = "Optional comment on staff member involvement", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val comment: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/ChangeStatusRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/ChangeStatusRequest.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 
-@Schema(description = "Changes an incident report’s status")
+@Schema(description = "Changes an incident report’s status", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class ChangeStatusRequest(
-  @Schema(description = "The new status", required = true, example = "CLOSED")
+  @Schema(description = "The new status", requiredMode = Schema.RequiredMode.REQUIRED, example = "CLOSED")
   val newStatus: Status,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/ChangeTypeRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/ChangeTypeRequest.kt
@@ -4,9 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.ValidationException
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 
-@Schema(description = "Changes an incident report’s type")
+@Schema(description = "Changes an incident report’s type", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class ChangeTypeRequest(
-  @Schema(description = "The new type", required = true, example = "DAMAGE")
+  @Schema(description = "The new type", requiredMode = Schema.RequiredMode.REQUIRED, example = "DAMAGE")
   val newType: Type,
 ) {
   fun validate() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
@@ -10,24 +10,24 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Event
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 import java.time.LocalDateTime
 
-@Schema(description = "Payload to create a new draft incident report")
+@Schema(description = "Payload to create a new draft incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class CreateReportRequest(
-  @Schema(description = "Incident report type", required = true)
+  @Schema(description = "Incident report type", requiredMode = Schema.RequiredMode.REQUIRED)
   val type: Type,
-  @Schema(description = "When the incident took place", required = true, example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the incident took place", requiredMode = Schema.RequiredMode.REQUIRED, example = "2024-04-29T12:34:56.789012")
   val incidentDateAndTime: LocalDateTime,
-  @Schema(description = "The NOMIS id of the prison where incident took place", required = true, example = "MDI", minLength = 2, maxLength = 6)
+  @Schema(description = "The NOMIS id of the prison where incident took place", requiredMode = Schema.RequiredMode.REQUIRED, example = "MDI", minLength = 2, maxLength = 6)
   @field:Size(min = 2, max = 6)
   val prisonId: String,
-  @Schema(description = "Brief title describing the incident", required = true, minLength = 5, maxLength = 255)
+  @Schema(description = "Brief title describing the incident", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 5, maxLength = 255)
   @field:Size(min = 5, max = 255)
   val title: String,
-  @Schema(description = "Longer summary of the incident", required = true, minLength = 1)
+  @Schema(description = "Longer summary of the incident", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
   @field:Size(min = 1)
   val description: String,
-  @Schema(description = "Whether to link to a new event", required = false, defaultValue = "false")
+  @Schema(description = "Whether to link to a new event", requiredMode = Schema.RequiredMode.NOT_REQUIRED, defaultValue = "false")
   val createNewEvent: Boolean = false,
-  @Schema(description = "Which existing event to link to", required = false, defaultValue = "null")
+  @Schema(description = "Which existing event to link to", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val linkedEventReference: String? = null,
 ) {
   fun validate(now: LocalDateTime) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/NomisSyncRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/NomisSyncRequest.kt
@@ -5,17 +5,9 @@ import jakarta.validation.ValidationException
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
 import java.util.UUID
 
-@Schema(description = "Incident report created/updated in NOMIS", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class NomisSyncRequest(
-  @Schema(
-    description = "For updates, this value is the UUID of the existing incident. For new incidents, this value is null.",
-    requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null",
-    example = "123e4567-e89b-12d3-a456-426614174000",
-  )
   val id: UUID? = null,
-  @Schema(description = "For initial migration this is true", requiredMode = Schema.RequiredMode.NOT_REQUIRED, defaultValue = "false")
   val initialMigration: Boolean = false,
-  @Schema(description = "Complete incident report payload", requiredMode = Schema.RequiredMode.REQUIRED)
   val incidentReport: NomisReport,
 ) {
   fun validate() {
@@ -23,4 +15,25 @@ data class NomisSyncRequest(
       throw ValidationException("Cannot update an existing report ($id) during initial migration")
     }
   }
+}
+
+@Schema(description = "Incident report created in NOMIS", accessMode = Schema.AccessMode.WRITE_ONLY)
+interface NomisSyncCreateRequest {
+  @get:Schema(description = "Set to true for initial migration", requiredMode = Schema.RequiredMode.REQUIRED, allowableValues = ["true"], example = "true")
+  val initialMigration: Boolean
+
+  @get:Schema(description = "Complete incident report payload", requiredMode = Schema.RequiredMode.REQUIRED)
+  val incidentReport: NomisReport
+}
+
+@Schema(description = "Incident report updated in NOMIS", accessMode = Schema.AccessMode.WRITE_ONLY)
+interface NomisSyncUpdateRequest {
+  @get:Schema(description = "Incident report ID", requiredMode = Schema.RequiredMode.REQUIRED, example = "123e4567-e89b-12d3-a456-426614174000")
+  val id: UUID
+
+  @get:Schema(description = "Omit or set to false for updates", requiredMode = Schema.RequiredMode.NOT_REQUIRED, defaultValue = "false", allowableValues = ["false"])
+  val initialMigration: Boolean
+
+  @get:Schema(description = "Complete incident report payload", requiredMode = Schema.RequiredMode.REQUIRED)
+  val incidentReport: NomisReport
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/NomisSyncRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/NomisSyncRequest.kt
@@ -5,17 +5,17 @@ import jakarta.validation.ValidationException
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
 import java.util.UUID
 
-@Schema(description = "Incident report created/updated in NOMIS")
+@Schema(description = "Incident report created/updated in NOMIS", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class NomisSyncRequest(
   @Schema(
     description = "For updates, this value is the UUID of the existing incident. For new incidents, this value is null.",
-    required = false,
+    requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null",
     example = "123e4567-e89b-12d3-a456-426614174000",
   )
   val id: UUID? = null,
-  @Schema(description = "For initial migration this is true", required = false, defaultValue = "false")
+  @Schema(description = "For initial migration this is true", requiredMode = Schema.RequiredMode.NOT_REQUIRED, defaultValue = "false")
   val initialMigration: Boolean = false,
-  @Schema(description = "Complete incident report payload", required = true)
+  @Schema(description = "Complete incident report payload", requiredMode = Schema.RequiredMode.REQUIRED)
   val incidentReport: NomisReport,
 ) {
   fun validate() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateCorrectionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateCorrectionRequest.kt
@@ -1,17 +1,19 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.CorrectionReason
 
-@Schema(description = "Update a correction request in an incident report")
+@Schema(description = "Update a correction request in an incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class UpdateCorrectionRequest(
-  @Schema(description = "Why the correction is needed", required = false, defaultValue = "null")
+  @Schema(description = "Why the correction is needed", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val reason: CorrectionReason? = null,
-  @Schema(description = "The changes being requested", required = false, defaultValue = "null", minLength = 1)
+  @Schema(description = "The changes being requested", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null", minLength = 1)
   @field:Size(min = 1)
   val descriptionOfChange: String? = null,
 ) {
+  @JsonIgnore
   val isEmpty: Boolean =
     reason == null && descriptionOfChange == null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdatePrisonerInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdatePrisonerInvolvement.kt
@@ -1,23 +1,25 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerOutcome
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerRole
 import java.util.Optional
 
-@Schema(description = "Update an involved prisoner in an incident report")
+@Schema(description = "Update an involved prisoner in an incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class UpdatePrisonerInvolvement(
-  @Schema(description = "Prisoner’s NOMIS number", required = false, defaultValue = "null", minLength = 7, maxLength = 10)
+  @Schema(description = "Prisoner’s NOMIS number", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null", minLength = 7, maxLength = 10)
   @field:Size(min = 7, max = 10)
   val prisonerNumber: String? = null,
-  @Schema(description = "Their role", required = false, defaultValue = "null")
+  @Schema(description = "Their role", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val prisonerRole: PrisonerRole? = null,
-  @Schema(description = "Optional outcome of prisoner’s involvement – omit to preserve existing outcome, provide null to clear it", required = false, defaultValue = "null")
+  @Schema(description = "Optional outcome of prisoner’s involvement – omit to preserve existing outcome, provide null to clear it", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
   val outcome: Optional<PrisonerOutcome>? = null,
-  @Schema(description = "Optional comment on prisoner’s involvement – omit to preserve existing comment, provide null to clear it", required = false, defaultValue = "null")
+  @Schema(description = "Optional comment on prisoner’s involvement – omit to preserve existing comment, provide null to clear it", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
   val comment: Optional<String>? = null,
 ) {
+  @JsonIgnore
   val isEmpty: Boolean =
     prisonerNumber == null && prisonerRole == null && outcome == null && comment == null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateReportRequest.kt
@@ -1,28 +1,30 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.ValidationException
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.Report
 import java.time.LocalDateTime
 
-@Schema(description = "Payload to update key properties of an incident report")
+@Schema(description = "Payload to update key properties of an incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class UpdateReportRequest(
-  @Schema(description = "When the incident took place", required = false, defaultValue = "null", example = "2024-04-29T12:34:56.789012")
+  @Schema(description = "When the incident took place", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null", example = "2024-04-29T12:34:56.789012")
   val incidentDateAndTime: LocalDateTime? = null,
-  @Schema(description = "The NOMIS id of the prison where incident took place", required = false, defaultValue = "null", example = "MDI", minLength = 2, maxLength = 6)
+  @Schema(description = "The NOMIS id of the prison where incident took place", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null", example = "MDI", minLength = 2, maxLength = 6)
   @field:Size(min = 2, max = 6)
   val prisonId: String? = null,
-  @Schema(description = "Brief title describing the incident", required = false, defaultValue = "null", minLength = 5, maxLength = 255)
+  @Schema(description = "Brief title describing the incident", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null", minLength = 5, maxLength = 255)
   @field:Size(min = 5, max = 255)
   val title: String? = null,
-  @Schema(description = "Longer summary of the incident", required = false, defaultValue = "null", minLength = 1)
+  @Schema(description = "Longer summary of the incident", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null", minLength = 1)
   @field:Size(min = 1)
   val description: String? = null,
 
-  @Schema(description = "Whether the parent event should also be updated", required = false, defaultValue = "false", example = "true")
+  @Schema(description = "Whether the parent event should also be updated", requiredMode = Schema.RequiredMode.NOT_REQUIRED, defaultValue = "false", example = "true")
   val updateEvent: Boolean = false,
 ) {
+  @JsonIgnore
   val isEmpty: Boolean =
     incidentDateAndTime == null && prisonId == null && title == null && description == null
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateStaffInvolvement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateStaffInvolvement.kt
@@ -1,20 +1,22 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.request
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 import java.util.Optional
 
-@Schema(description = "Update an involved member of staff in an incident report")
+@Schema(description = "Update an involved member of staff in an incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class UpdateStaffInvolvement(
-  @Schema(description = "Username", required = false, defaultValue = "null", minLength = 3, maxLength = 120)
+  @Schema(description = "Username", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null", minLength = 3, maxLength = 120)
   @field:Size(min = 3, max = 120)
   val staffUsername: String? = null,
-  @Schema(description = "Their role", required = false, defaultValue = "null")
+  @Schema(description = "Their role", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val staffRole: StaffRole? = null,
-  @Schema(description = "Optional comment on staff member involvement – omit to preserve existing comment, provide null to clear it", required = false, defaultValue = "null")
+  @Schema(description = "Optional comment on staff member involvement – omit to preserve existing comment, provide null to clear it", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
   val comment: Optional<String>? = null,
 ) {
+  @JsonIgnore
   val isEmpty: Boolean =
     staffUsername == null && staffRole == null && comment == null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/ConstantDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/ConstantDescription.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Code and description of a constant or enumeration member")
+@Schema(description = "Code and description of a constant or enumeration member", accessMode = Schema.AccessMode.READ_ONLY)
+@JsonInclude(JsonInclude.Include.ALWAYS)
 data class ConstantDescription(
-  @Schema(description = "Machine-readable identifier of this value", required = true, readOnly = true, example = "VICTIM")
+  @Schema(description = "Machine-readable identifier of this value", example = "VICTIM")
   val code: String,
-  @Schema(description = "Human-readable description of this value", required = true, readOnly = true, example = "Victim")
+  @Schema(description = "Human-readable description of this value", example = "Victim")
   val description: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/NomisSyncReportId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/NomisSyncReportId.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
-@Schema(description = "Incident report ID")
+@Schema(description = "Incident report ID", accessMode = Schema.AccessMode.READ_ONLY)
+@JsonInclude(JsonInclude.Include.ALWAYS)
 data class NomisSyncReportId(
-  @Schema(description = "The internal ID of this report", required = true)
+  @Schema(description = "The internal ID of this report")
   val id: UUID,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/SimplePage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/SimplePage.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.response
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.data.domain.Page
@@ -10,6 +11,8 @@ import org.springframework.data.domain.Sort
  * `org.springframework.data.domain.PageImpl` serialises with excessive and redundant properties.
  * This class creates simpler JSON.
  */
+@Schema(description = "Page of results", accessMode = Schema.AccessMode.READ_ONLY)
+@JsonInclude(JsonInclude.Include.ALWAYS)
 data class SimplePage<T>(
   @Schema(description = "Elements in this pages", example = "[…]")
   val content: List<T>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/TypeConstantDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/TypeConstantDescription.kt
@@ -1,17 +1,19 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Incident type constant")
+@Schema(description = "Incident type constant", accessMode = Schema.AccessMode.READ_ONLY)
+@JsonInclude(JsonInclude.Include.ALWAYS)
 data class TypeConstantDescription(
-  @Schema(description = "Machine-readable identifier of this value", required = true, readOnly = true, example = "DISORDER")
+  @Schema(description = "Machine-readable identifier of this value", example = "DISORDER")
   val code: String,
-  @Schema(description = "Human-readable description of this value", required = true, readOnly = true, example = "Disorder")
+  @Schema(description = "Human-readable description of this value", example = "Disorder")
   val description: String,
-  @Schema(description = "Whether this type is currently active and usable in new reports", required = false, readOnly = true, defaultValue = "true", example = "true")
+  @Schema(description = "Whether this type is currently active and usable in new reports", example = "true")
   val active: Boolean = true,
 
   // NB: this property can be removed once fully migrated off NOMIS and reconciliation checks are turned off
-  @Schema(description = "Machine-readable NOMIS identifier of this value, which may be null for newer incident types", required = false, readOnly = true, example = "DISORDER1", deprecated = true)
+  @Schema(description = "Machine-readable NOMIS identifier of this value, which may be null for newer incident types", nullable = true, example = "DISORDER1", deprecated = true)
   val nomisCode: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ErrorResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ErrorResponse.kt
@@ -3,17 +3,17 @@ package uk.gov.justice.digital.hmpps.incidentreporting.resource
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.HttpStatus
 
-@Schema(description = "Error response")
+@Schema(description = "Error response", accessMode = Schema.AccessMode.READ_ONLY)
 data class ErrorResponse(
-  @Schema(description = "HTTP status code", example = "500", required = true)
+  @Schema(description = "HTTP status code", example = "500")
   val status: Int,
-  @Schema(description = "User message for the error", example = "No incident report found for ID `55544222`", required = true)
+  @Schema(description = "User message for the error", example = "No incident report found for ID `55544222`")
   val userMessage: String,
-  @Schema(description = "More detailed error message", example = "[Details, sometimes a stack trace]", required = true)
+  @Schema(description = "More detailed error message", example = "[Details, sometimes a stack trace]")
   val developerMessage: String,
-  @Schema(description = "When present, uniquely identifies the type of error making it easier for clients to discriminate without relying on error description or HTTP status code; see ` uk.gov.justice.digital.hmpps.incidentreporting.resource.ErrorCode` enumeration in hmpps-incident-reporting-api", example = "101", required = false)
+  @Schema(description = "When present, uniquely identifies the type of error making it easier for clients to discriminate without relying on error description or HTTP status code; see ` uk.gov.justice.digital.hmpps.incidentreporting.resource.ErrorCode` enumeration in hmpps-incident-reporting-api", example = "101", nullable = true, defaultValue = "null")
   val errorCode: Int? = null,
-  @Schema(description = "More information about the error", example = "[Rarely used, error-specific]", required = false)
+  @Schema(description = "More information about the error", example = "[Rarely used, error-specific]", nullable = true, defaultValue = "null")
   val moreInfo: String? = null,
 ) {
   constructor(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/EventResource.kt
@@ -69,7 +69,8 @@ class EventResource(
   fun getEvents(
     @Schema(
       description = "Filter by given prison ID",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "MDI",
       minLength = 2,
@@ -80,7 +81,8 @@ class EventResource(
     prisonId: String? = null,
     @Schema(
       description = "Filter for events that happened since this date (inclusive)",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "2024-01-01",
       format = "date",
@@ -89,7 +91,8 @@ class EventResource(
     eventDateFrom: LocalDate? = null,
     @Schema(
       description = "Filter for events that happened until this date (inclusive)",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "2024-05-31",
       format = "date",
@@ -141,7 +144,7 @@ class EventResource(
     ],
   )
   fun getEventById(
-    @Schema(description = "The event id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The event id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     id: UUID,
   ): EventWithBasicReports {
@@ -178,7 +181,7 @@ class EventResource(
     ],
   )
   fun getEventByReference(
-    @Schema(description = "The event reference", example = "2342341242", required = true)
+    @Schema(description = "The event reference", example = "2342341242", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     eventReference: String,
   ): EventWithBasicReports {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResource.kt
@@ -16,7 +16,9 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.InformationSource
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.NomisSyncCreateRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.NomisSyncRequest
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.request.NomisSyncUpdateRequest
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.NomisSyncReportId
 import uk.gov.justice.digital.hmpps.incidentreporting.service.NomisSyncService
 import uk.gov.justice.digital.hmpps.incidentreporting.service.ReportDomainEventType
@@ -70,6 +72,11 @@ class NomisSyncResource(
     ],
   )
   fun upsertIncidentReport(
+    @Schema(
+      description = "Incident report created/updated in NOMIS",
+      accessMode = Schema.AccessMode.WRITE_ONLY,
+      oneOf = [NomisSyncCreateRequest::class, NomisSyncUpdateRequest::class],
+    )
     @RequestBody
     @Valid
     syncRequest: NomisSyncRequest,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportCorrectionRequestResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportCorrectionRequestResource.kt
@@ -58,7 +58,7 @@ class ReportCorrectionRequestResource : ReportRelatedObjectsResource<CorrectionR
   )
   @Transactional(readOnly = true)
   override fun listObjects(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
   ): List<CorrectionRequest> {
@@ -101,7 +101,7 @@ class ReportCorrectionRequestResource : ReportRelatedObjectsResource<CorrectionR
   )
   @Transactional
   override fun addObject(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
     @RequestBody
@@ -159,10 +159,10 @@ class ReportCorrectionRequestResource : ReportRelatedObjectsResource<CorrectionR
   )
   @Transactional
   override fun updateObject(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
-    @Schema(description = "The index of the object to update (starts from 1)", example = "1", required = true)
+    @Schema(description = "The index of the object to update (starts from 1)", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     index: Int,
     @RequestBody
@@ -217,10 +217,10 @@ class ReportCorrectionRequestResource : ReportRelatedObjectsResource<CorrectionR
   )
   @Transactional
   override fun removeObject(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
-    @Schema(description = "The index of the object to delete (starts from 1)", example = "1", required = true)
+    @Schema(description = "The index of the object to delete (starts from 1)", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     index: Int,
   ): List<CorrectionRequest> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportPrisonerInvolvementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportPrisonerInvolvementResource.kt
@@ -56,7 +56,7 @@ class ReportPrisonerInvolvementResource : ReportRelatedObjectsResource<PrisonerI
   )
   @Transactional(readOnly = true)
   override fun listObjects(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
   ): List<PrisonerInvolvement> {
@@ -99,7 +99,7 @@ class ReportPrisonerInvolvementResource : ReportRelatedObjectsResource<PrisonerI
   )
   @Transactional
   override fun addObject(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
     @RequestBody
@@ -157,10 +157,10 @@ class ReportPrisonerInvolvementResource : ReportRelatedObjectsResource<PrisonerI
   )
   @Transactional
   override fun updateObject(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
-    @Schema(description = "The index of the object to update (starts from 1)", example = "1", required = true)
+    @Schema(description = "The index of the object to update (starts from 1)", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     index: Int,
     @RequestBody
@@ -211,10 +211,10 @@ class ReportPrisonerInvolvementResource : ReportRelatedObjectsResource<PrisonerI
   )
   @Transactional
   override fun removeObject(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
-    @Schema(description = "The index of the object to delete (starts from 1)", example = "1", required = true)
+    @Schema(description = "The index of the object to delete (starts from 1)", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     index: Int,
   ): List<PrisonerInvolvement> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportQuestionResponseResource.kt
@@ -65,7 +65,7 @@ class ReportQuestionResponseResource(
     ],
   )
   fun getQuestionsAndResponses(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
   ): List<Question> {
@@ -107,7 +107,7 @@ class ReportQuestionResponseResource(
     ],
   )
   fun addQuestionWithResponses(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
     @RequestBody
@@ -160,7 +160,7 @@ class ReportQuestionResponseResource(
     ],
   )
   fun deleteLastQuestionAndResponses(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
   ): List<Question> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -86,7 +86,8 @@ class ReportResource(
   fun getBasicReports(
     @Schema(
       description = "Filter by given prison ID",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "MDI",
       minLength = 2,
@@ -97,7 +98,8 @@ class ReportResource(
     prisonId: String? = null,
     @Schema(
       description = "Filter by given information source",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "DPS",
       implementation = InformationSource::class,
@@ -110,7 +112,8 @@ class ReportResource(
       array = ArraySchema(
         schema = Schema(implementation = Status::class),
         arraySchema = Schema(
-          required = false,
+          requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+          nullable = true,
           defaultValue = "null",
         ),
       ),
@@ -119,7 +122,8 @@ class ReportResource(
     status: List<Status>? = null,
     @Schema(
       description = "Filter by given incident type",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "DAMAGE",
       implementation = Type::class,
@@ -128,7 +132,8 @@ class ReportResource(
     type: Type? = null,
     @Schema(
       description = "Filter for incidents occurring since this date (inclusive)",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "2024-01-01",
       format = "date",
@@ -137,7 +142,8 @@ class ReportResource(
     incidentDateFrom: LocalDate? = null,
     @Schema(
       description = "Filter for incidents occurring until this date (inclusive)",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "2024-05-31",
       format = "date",
@@ -146,7 +152,8 @@ class ReportResource(
     incidentDateUntil: LocalDate? = null,
     @Schema(
       description = "Filter for incidents reported since this date (inclusive)",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "2024-01-01",
       format = "date",
@@ -155,7 +162,8 @@ class ReportResource(
     reportedDateFrom: LocalDate? = null,
     @Schema(
       description = "Filter for incidents reported until this date (inclusive)",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "2024-05-31",
       format = "date",
@@ -164,7 +172,8 @@ class ReportResource(
     reportedDateUntil: LocalDate? = null,
     @Schema(
       description = "Filter for incidents involving staff identified by username",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "abc12a",
     )
@@ -173,7 +182,8 @@ class ReportResource(
     involvingStaffUsername: String? = null,
     @Schema(
       description = "Filter for incidents involving prisoners identified by prisoner number",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+      nullable = true,
       defaultValue = "null",
       example = "A1234AA",
     )
@@ -232,7 +242,7 @@ class ReportResource(
     ],
   )
   fun getBasicReportById(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     id: UUID,
   ): ReportBasic {
@@ -269,7 +279,7 @@ class ReportResource(
     ],
   )
   fun getReportWithDetailsById(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     id: UUID,
   ): ReportWithDetails {
@@ -306,7 +316,7 @@ class ReportResource(
     ],
   )
   fun getBasicReportByReference(
-    @Schema(description = "The incident report reference", example = "2342341242", required = true)
+    @Schema(description = "The incident report reference", example = "2342341242", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportReference: String,
   ): ReportBasic {
@@ -343,7 +353,7 @@ class ReportResource(
     ],
   )
   fun getReportWithDetailsByReference(
-    @Schema(description = "The incident report reference", example = "2342341242", required = true)
+    @Schema(description = "The incident report reference", example = "2342341242", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportReference: String,
   ): ReportWithDetails {
@@ -431,7 +441,7 @@ class ReportResource(
     ],
   )
   fun updateReport(
-    @Schema(description = "The internal ID of the report to update", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The internal ID of the report to update", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     id: UUID,
     @RequestBody
@@ -487,7 +497,7 @@ class ReportResource(
     ],
   )
   fun changeReportStatus(
-    @Schema(description = "The internal ID of the report to update", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The internal ID of the report to update", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     id: UUID,
     @RequestBody
@@ -542,7 +552,7 @@ class ReportResource(
     ],
   )
   fun changeReportType(
-    @Schema(description = "The internal ID of the report to update", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The internal ID of the report to update", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     id: UUID,
     @RequestBody
@@ -598,12 +608,12 @@ class ReportResource(
     ],
   )
   fun deleteReport(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     id: UUID,
     @Schema(
       description = "Whether orphaned events should also be deleted",
-      required = false,
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
       defaultValue = "true",
       example = "false",
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportStaffInvolvementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportStaffInvolvementResource.kt
@@ -56,7 +56,7 @@ class ReportStaffInvolvementResource : ReportRelatedObjectsResource<StaffInvolve
   )
   @Transactional(readOnly = true)
   override fun listObjects(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
   ): List<StaffInvolvement> {
@@ -99,7 +99,7 @@ class ReportStaffInvolvementResource : ReportRelatedObjectsResource<StaffInvolve
   )
   @Transactional
   override fun addObject(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
     @RequestBody
@@ -156,10 +156,10 @@ class ReportStaffInvolvementResource : ReportRelatedObjectsResource<StaffInvolve
   )
   @Transactional
   override fun updateObject(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
-    @Schema(description = "The index of the object to update (starts from 1)", example = "1", required = true)
+    @Schema(description = "The index of the object to update (starts from 1)", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     index: Int,
     @RequestBody
@@ -210,10 +210,10 @@ class ReportStaffInvolvementResource : ReportRelatedObjectsResource<StaffInvolve
   )
   @Transactional
   override fun removeObject(
-    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", required = true)
+    @Schema(description = "The incident report id", example = "11111111-2222-3333-4444-555555555555", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     reportId: UUID,
-    @Schema(description = "The index of the object to delete (starts from 1)", example = "1", required = true)
+    @Schema(description = "The index of the object to delete (starts from 1)", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
     @PathVariable
     index: Int,
   ): List<StaffInvolvement> {


### PR DESCRIPTION
1) they are either read-only (used only for responses) or write-only (used only for requests)
2) some fields are nullable
3) for write-only request types, some fields are required and some are optional
4) stop using the deprecated `required` attribute