### PR TITLE
IR-431: Local setup

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -2,9 +2,9 @@ services:
 
   localstack:
     image: localstack/localstack:3
+    container_name: irs-localstack
     networks:
       - hmpps
-    container_name: localstack
     ports:
       - "4566:4566"
       - "8999:8080"
@@ -16,10 +16,10 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
   incident-reporting-db:
-    image: postgres
+    image: postgres:16
+    container_name: irs-postgres
     networks:
       - hmpps
-    container_name: incident-reporting-db
     restart: unless-stopped
     ports:
       - "5432:5432"


### PR DESCRIPTION
Use the same docker image tags and container names as UI app’s docker compose setup.

See also [ui#158](https://github.com/ministryofjustice/hmpps-incident-reporting/pull/158)