### PR TITLE
Expose `nomisCode` in PrisonerRole constants endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/PrisonerRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/PrisonerRole.kt
@@ -4,48 +4,30 @@ import jakarta.validation.ValidationException
 
 enum class PrisonerRole(
   val description: String,
+  val nomisCode: String,
 ) {
-  ABSCONDER("Absconder"),
-  ACTIVE_INVOLVEMENT("Active involvement"),
-  ASSAILANT("Assailant"),
-  ASSISTED_STAFF("Assisted staff"),
-  DECEASED("Deceased"),
-  ESCAPE("Escapee"),
-  FIGHTER("Fighter"),
-  HOSTAGE("Hostage"),
-  IMPEDED_STAFF("Impeded staff"),
-  IN_POSSESSION("In possession"),
-  INTENDED_RECIPIENT("Intended recipient"),
-  LICENSE_FAILURE("License failure"),
-  PERPETRATOR("Perpetrator"),
-  PRESENT_AT_SCENE("Present at scene"),
-  SUSPECTED_ASSAILANT("Suspected assailant"),
-  SUSPECTED_INVOLVED("Suspected involved"),
-  TEMPORARY_RELEASE_FAILURE("Temporary release failure"),
-  VICTIM("Victim"),
+  ABSCONDER("Absconder", "ABS"),
+  ACTIVE_INVOLVEMENT("Active involvement", "ACTINV"),
+  ASSAILANT("Assailant", "ASSIAL"),
+  ASSISTED_STAFF("Assisted staff", "ASSIST"),
+  DECEASED("Deceased", "DEC"),
+  ESCAPE("Escapee", "ESC"),
+  FIGHTER("Fighter", "FIGHT"),
+  HOSTAGE("Hostage", "HOST"),
+  IMPEDED_STAFF("Impeded staff", "IMPED"),
+  IN_POSSESSION("In possession", "INPOSS"),
+  INTENDED_RECIPIENT("Intended recipient", "INREC"),
+  LICENSE_FAILURE("License failure", "LICFAIL"),
+  PERPETRATOR("Perpetrator", "PERP"),
+  PRESENT_AT_SCENE("Present at scene", "PRESENT"),
+  SUSPECTED_ASSAILANT("Suspected assailant", "SUSASS"),
+  SUSPECTED_INVOLVED("Suspected involved", "SUSINV"),
+  TEMPORARY_RELEASE_FAILURE("Temporary release failure", "TRF"),
+  VICTIM("Victim", "VICT"),
   ;
 
   companion object {
-    fun fromNomisCode(role: String): PrisonerRole = when (role) {
-      "ABS" -> ABSCONDER
-      "ACTINV" -> ACTIVE_INVOLVEMENT
-      "ASSIAL" -> ASSAILANT
-      "ASSIST" -> ASSISTED_STAFF
-      "DEC" -> DECEASED
-      "ESC" -> ESCAPE
-      "FIGHT" -> FIGHTER
-      "HOST" -> HOSTAGE
-      "IMPED" -> IMPEDED_STAFF
-      "INPOSS" -> IN_POSSESSION
-      "INREC" -> INTENDED_RECIPIENT
-      "LICFAIL" -> LICENSE_FAILURE
-      "PERP" -> PERPETRATOR
-      "PRESENT" -> PRESENT_AT_SCENE
-      "SUSASS" -> SUSPECTED_ASSAILANT
-      "SUSINV" -> SUSPECTED_INVOLVED
-      "TRF" -> TEMPORARY_RELEASE_FAILURE
-      "VICT" -> VICTIM
-      else -> throw ValidationException("Unknown NOMIS prisoner role: $role")
-    }
+    fun fromNomisCode(code: String): PrisonerRole = entries.find { it.nomisCode == code }
+      ?: throw ValidationException("Unknown NOMIS prisoner role code: $code")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/PrisonerRoleConstantDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/PrisonerRoleConstantDescription.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto.response
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Prisoner role constant", accessMode = Schema.AccessMode.READ_ONLY)
+@JsonInclude(JsonInclude.Include.ALWAYS)
+data class PrisonerRoleConstantDescription(
+  @Schema(description = "Machine-readable identifier of this value", example = "IMPEDED_STAFF")
+  val code: String,
+  @Schema(description = "Human-readable description of this value", example = "Impeded staff")
+  val description: String,
+
+  // NB: this property can be removed once fully migrated off NOMIS and reconciliation checks are turned off
+  @Schema(description = "Machine-readable NOMIS identifier of this value, which may be null for newer prisoner roles", nullable = true, example = "IMPED", deprecated = true)
+  val nomisCode: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResource.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.StaffRole
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.ConstantDescription
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.PrisonerRoleConstantDescription
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.TypeConstantDescription
 
 @RestController
@@ -104,9 +105,9 @@ class ConstantsResource {
       ),
     ],
   )
-  fun prisonerRoles(): List<ConstantDescription> {
+  fun prisonerRoles(): List<PrisonerRoleConstantDescription> {
     return PrisonerRole.entries.map {
-      ConstantDescription(it.name, it.description)
+      PrisonerRoleConstantDescription(it.name, it.description, it.nomisCode)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerRole
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.integration.SqsIntegrationTestBase
 
@@ -55,6 +56,30 @@ class ConstantsResourceTest : SqsIntegrationTestBase() {
             "description" to "Assault (from April 2017)",
             "active" to false,
             "nomisCode" to "ASSAULTS1",
+          ),
+        )
+      }
+  }
+
+  @Test
+  fun `exposes NOMIS prisoner roles codes`() {
+    webTestClient.get().uri("/constants/prisoner-roles")
+      .headers(setAuthorisation(roles = emptyList(), scopes = listOf("read")))
+      .header("Content-Type", "application/json")
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("$").value<List<Map<String, Any?>>> { list ->
+        assertThat(list).hasSize(PrisonerRole.entries.size)
+        assertThat(list).containsOnlyOnce(
+          mapOf(
+            "code" to "ABSCONDER",
+            "description" to "Absconder",
+            "nomisCode" to "ABS",
+          ),
+          mapOf(
+            "code" to "IMPEDED_STAFF",
+            "description" to "Impeded staff",
+            "nomisCode" to "IMPED",
           ),
         )
       }


### PR DESCRIPTION
These codes can be used by the UI to map between an old `PrisonerInvolvemtRole` and a new `PrisonerInvolvemtRole`.