### PR TITLE
IR-535: Expose NOMIS code for statuses when returning reports with details

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2023 Crown Copyright (Ministry of Justice)
+Copyright (c) 2020-2024 Crown Copyright (Ministry of Justice)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-validation")
 
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.0.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.0.1")
   implementation("io.opentelemetry:opentelemetry-api:1.42.1")
   implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.8.0")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
@@ -4,29 +4,21 @@ import jakarta.validation.ValidationException
 
 enum class Status(
   val description: String,
+  val nomisStatus: String?,
 ) {
-  DRAFT("Draft"),
-  AWAITING_ANALYSIS("Awaiting analysis"),
-  IN_ANALYSIS("In analysis"),
-  INFORMATION_REQUIRED("Information required"),
-  INFORMATION_AMENDED("Information amened"),
-  CLOSED("Closed"),
-  POST_INCIDENT_UPDATE("Post-incident update"),
-  INCIDENT_UPDATED("Incident updated"),
-  DUPLICATE("Duplicate"),
+  DRAFT("Draft", null),
+  AWAITING_ANALYSIS("Awaiting analysis", "AWAN"),
+  IN_ANALYSIS("In analysis", "INAN"),
+  INFORMATION_REQUIRED("Information required", "INREQ"),
+  INFORMATION_AMENDED("Information amened", "INAME"),
+  CLOSED("Closed", "CLOSE"),
+  POST_INCIDENT_UPDATE("Post-incident update", "PIU"),
+  INCIDENT_UPDATED("Incident updated", "IUP"),
+  DUPLICATE("Duplicate", "DUP"),
   ;
 
   companion object {
-    fun fromNomisCode(status: String): Status = when (status) {
-      "AWAN" -> AWAITING_ANALYSIS
-      "INAN" -> IN_ANALYSIS
-      "INREQ" -> INFORMATION_REQUIRED
-      "INAME" -> INFORMATION_AMENDED
-      "CLOSE" -> CLOSED
-      "PIU" -> POST_INCIDENT_UPDATE
-      "IUP" -> INCIDENT_UPDATED
-      "DUP" -> DUPLICATE
-      else -> throw ValidationException("Unknown NOMIS incident status: $status")
-    }
+    fun fromNomisCode(status: String): Status = Status.entries.find { it.nomisStatus == status }
+      ?: throw ValidationException("Unknown NOMIS incident status: $status")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
@@ -65,4 +65,10 @@ class ReportWithDetails(
   @get:JsonProperty
   val nomisType: String?
     get() = type.nomisType
+
+  // NB: this property can be removed once fully migrated off NOMIS and reconciliation checks are turned off
+  @get:Schema(description = "Previous NOMIS incident report status code, which may be null for statuses that cannot be mapped", nullable = true, deprecated = true)
+  @get:JsonProperty
+  val nomisStatus: String?
+    get() = status.nomisStatus
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/StatusHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/StatusHistory.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incidentreporting.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import java.time.LocalDateTime
@@ -8,10 +9,16 @@ import java.time.LocalDateTime
 @Schema(description = "Previous statuses an incident report transitioned to", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class StatusHistory(
-  @Schema(description = "Previous current status of an incident report")
+  @Schema(description = "Previous status of an incident report")
   val status: Status,
   @Schema(description = "When the report status was changed", example = "2024-04-29T12:34:56.789012")
   val changedAt: LocalDateTime,
   @Schema(description = "The member of staff who changed the report status")
   val changedBy: String,
-)
+) {
+  // NB: this property can be removed once fully migrated off NOMIS and reconciliation checks are turned off
+  @get:Schema(description = "Previous NOMIS incident report status code, which may be null for statuses that cannot be mapped", nullable = true, deprecated = true)
+  @get:JsonProperty
+  val nomisStatus: String?
+    get() = status.nomisStatus
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/StatusConstantDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/StatusConstantDescription.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto.response
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Report status constant", accessMode = Schema.AccessMode.READ_ONLY)
+@JsonInclude(JsonInclude.Include.ALWAYS)
+data class StatusConstantDescription(
+  @Schema(description = "Machine-readable identifier of this value", example = "IN_ANALYSIS")
+  val code: String,
+  @Schema(description = "Human-readable description of this value", example = "In analysis")
+  val description: String,
+
+  // NB: this property can be removed once fully migrated off NOMIS and reconciliation checks are turned off
+  @Schema(description = "Machine-readable NOMIS identifier of this value, which may be null for statuses that cannot be mapped", nullable = true, example = "INAN", deprecated = true)
+  val nomisCode: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/TypeConstantDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/TypeConstantDescription.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.incidentreporting.dto.response
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Incident type constant", accessMode = Schema.AccessMode.READ_ONLY)
+@Schema(description = "Report type constant", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class TypeConstantDescription(
   @Schema(description = "Machine-readable identifier of this value", example = "DISORDER")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResource.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.ConstantDescription
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.PrisonerRoleConstantDescription
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.StatusConstantDescription
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.response.TypeConstantDescription
 
 @RestController
@@ -139,9 +140,9 @@ class ConstantsResource {
       ),
     ],
   )
-  fun statuses(): List<ConstantDescription> {
+  fun statuses(): List<StatusConstantDescription> {
     return Status.entries.map {
-      ConstantDescription(it.name, it.description)
+      StatusConstantDescription(it.name, it.description, it.nomisStatus)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.PrisonerRole
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
 import uk.gov.justice.digital.hmpps.incidentreporting.integration.SqsIntegrationTestBase
 
@@ -36,7 +37,7 @@ class ConstantsResourceTest : SqsIntegrationTestBase() {
   }
 
   @Test
-  fun `exposes NOMIS incident types`() {
+  fun `exposes NOMIS report types`() {
     webTestClient.get().uri("/constants/types")
       .headers(setAuthorisation(roles = emptyList(), scopes = listOf("read")))
       .header("Content-Type", "application/json")
@@ -56,6 +57,30 @@ class ConstantsResourceTest : SqsIntegrationTestBase() {
             "description" to "Assault (from April 2017)",
             "active" to false,
             "nomisCode" to "ASSAULTS1",
+          ),
+        )
+      }
+  }
+
+  @Test
+  fun `exposes NOMIS report statuses`() {
+    webTestClient.get().uri("/constants/statuses")
+      .headers(setAuthorisation(roles = emptyList(), scopes = listOf("read")))
+      .header("Content-Type", "application/json")
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("$").value<List<Map<String, Any?>>> { list ->
+        assertThat(list).hasSize(Status.entries.size)
+        assertThat(list).containsOnlyOnce(
+          mapOf(
+            "code" to "DRAFT",
+            "description" to "Draft",
+            "nomisCode" to null,
+          ),
+          mapOf(
+            "code" to "IN_ANALYSIS",
+            "description" to "In analysis",
+            "nomisCode" to "INAN",
           ),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -620,6 +620,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "historyOfStatuses": [
                   {
                     "status": "AWAITING_ANALYSIS",
+                    "nomisStatus": "AWAN",
                     "changedAt": "2023-12-05T12:34:56",
                     "changedBy": "user2"
                   }
@@ -656,6 +657,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "reportedBy": "user2",
                 "reportedAt": "2023-12-05T12:34:56",
                 "status": "AWAITING_ANALYSIS",
+                "nomisStatus": "AWAN",
                 "assignedTo": "user2",
                 "createdAt": "2023-12-05T14:34:56",
                 "modifiedAt": "2023-12-05T17:34:56",
@@ -903,6 +905,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "historyOfStatuses": [
                   {
                     "status": "AWAITING_ANALYSIS",
+                    "nomisStatus": "AWAN",
                     "changedAt": "2023-12-05T12:34:56",
                     "changedBy": "user2"
                   }
@@ -939,6 +942,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "reportedBy": "user2",
                 "reportedAt": "2023-12-05T12:34:56",
                 "status": "AWAITING_ANALYSIS",
+                "nomisStatus": "AWAN",
                 "assignedTo": "user2",
                 "createdAt": "2023-12-05T14:34:56",
                 "modifiedAt": "2023-12-05T17:34:56",
@@ -1405,11 +1409,13 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "historyOfStatuses": [
                   {
                     "status": "DRAFT",
+                    "nomisStatus": null,
                     "changedAt": "2023-12-05T12:34:56",
                     "changedBy": "USER1"
                   },
                   {
                     "status": "IN_ANALYSIS",
+                    "nomisStatus": "INAN",
                     "changedAt": "2023-12-05T12:34:56",
                     "changedBy": "updater"
                   }
@@ -1457,6 +1463,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "reportedBy": "OF42",
                 "reportedAt": "2023-12-04T12:34:56",
                 "status": "IN_ANALYSIS",
+                "nomisStatus": "INAN",
                 "assignedTo": "USER1",
                 "createdAt": "2023-12-04T12:34:56",
                 "modifiedAt": "2023-12-05T12:29:56",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -564,6 +564,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "historyOfStatuses": [
                 {
                   "status": "DRAFT",
+                  "nomisStatus": null,
                   "changedAt": "2023-12-05T12:34:56",
                   "changedBy": "USER1"
                 }
@@ -574,6 +575,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "reportedBy": "USER1",
               "reportedAt": "2023-12-05T12:34:56",
               "status": "DRAFT",
+              "nomisStatus": null,
               "assignedTo": "USER1",
               "createdAt": "2023-12-05T12:34:56",
               "modifiedAt": "2023-12-05T12:34:56",
@@ -730,6 +732,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "historyOfStatuses": [
                 {
                   "status": "DRAFT",
+                  "nomisStatus": null,
                   "changedAt": "2023-12-05T12:34:56",
                   "changedBy": "USER1"
                 }
@@ -740,6 +743,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "reportedBy": "USER1",
               "reportedAt": "2023-12-05T12:34:56",
               "status": "DRAFT",
+              "nomisStatus": null,
               "assignedTo": "USER1",
               "createdAt": "2023-12-05T12:34:56",
               "modifiedAt": "2023-12-05T12:34:56",
@@ -902,6 +906,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "historyOfStatuses": [
                 {
                   "status": "DRAFT",
+                  "nomisStatus": null,
                   "changedAt": "2023-12-05T12:34:56",
                   "changedBy": "request-user"
                 }
@@ -912,6 +917,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "reportedBy": "request-user",
               "reportedAt": "2023-12-05T12:34:56",
               "status": "DRAFT",
+              "nomisStatus": null,
               "assignedTo": "request-user",
               "createdAt": "2023-12-05T12:34:56",
               "modifiedAt": "2023-12-05T12:34:56",
@@ -963,6 +969,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "historyOfStatuses": [
                 {
                   "status": "DRAFT",
+                  "nomisStatus": null,
                   "changedAt": "2023-12-05T12:34:56",
                   "changedBy": "request-user"
                 }
@@ -973,6 +980,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "reportedBy": "request-user",
               "reportedAt": "2023-12-05T12:34:56",
               "status": "DRAFT",
+              "nomisStatus": null,
               "assignedTo": "request-user",
               "createdAt": "2023-12-05T12:34:56",
               "modifiedAt": "2023-12-05T12:34:56",
@@ -1403,6 +1411,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "reportedBy": "USER1",
               "reportedAt": "2023-12-05T12:34:56",
               "status": "DRAFT",
+              "nomisStatus": null,
               "assignedTo": "USER1",
               "createdAt": "2023-12-05T12:34:56",
               "modifiedAt": "2023-12-05T12:34:56",
@@ -1411,6 +1420,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "historyOfStatuses": [
                 {
                   "status": "DRAFT",
+                  "nomisStatus": null,
                   "changedAt": "2023-12-05T12:34:56",
                   "changedBy": "USER1"
                 }
@@ -1446,6 +1456,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "reportedBy": "USER1",
               "reportedAt": "2023-12-05T12:34:56",
               "status": "AWAITING_ANALYSIS",
+              "nomisStatus": "AWAN",
               "assignedTo": "USER1",
               "createdAt": "2023-12-05T12:34:56",
               "modifiedAt": "2023-12-05T12:34:56",
@@ -1454,11 +1465,13 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "historyOfStatuses": [
                 {
                   "status": "DRAFT",
+                  "nomisStatus": null,
                   "changedAt": "2023-12-05T12:34:56",
                   "changedBy": "USER1"
                 },
                 {
                   "status": "AWAITING_ANALYSIS",
+                  "nomisStatus": "AWAN",
                   "changedAt": "2023-12-05T12:34:56",
                   "changedBy": "request-user"
                 }
@@ -1616,6 +1629,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "reportedBy": "USER1",
               "reportedAt": "2023-12-05T12:31:56",
               "status": "AWAITING_ANALYSIS",
+              "nomisStatus": "AWAN",
               "assignedTo": "USER1",
               "createdAt": "2023-12-05T12:31:56",
               "modifiedAt": "2023-12-05T12:31:56",
@@ -1707,6 +1721,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "reportedBy": "USER1",
               "reportedAt": "2023-12-05T12:31:56",
               "status": "AWAITING_ANALYSIS",
+              "nomisStatus": "AWAN",
               "assignedTo": "USER1",
               "createdAt": "2023-12-05T12:31:56",
               "modifiedAt": "2023-12-05T12:34:56",
@@ -1811,6 +1826,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "reportedBy": "USER1",
               "reportedAt": "2023-12-05T12:31:56",
               "status": "AWAITING_ANALYSIS",
+              "nomisStatus": "AWAN",
               "assignedTo": "USER1",
               "createdAt": "2023-12-05T12:31:56",
               "modifiedAt": "2023-12-05T12:34:56",

--- a/src/test/resources/entity-mapping/sample-report-with-details.json
+++ b/src/test/resources/entity-mapping/sample-report-with-details.json
@@ -9,6 +9,7 @@
   "reportedBy": "USER1",
   "reportedAt": "2023-12-05T12:34:56",
   "status": "DRAFT",
+  "nomisStatus": null,
   "assignedTo": "USER1",
   "createdAt": "2023-12-05T12:34:56",
   "modifiedAt": "2023-12-05T12:34:56",
@@ -236,6 +237,7 @@
   "historyOfStatuses": [
     {
       "status": "DRAFT",
+      "nomisStatus": null,
       "changedAt": "2023-12-05T12:34:56",
       "changedBy": "USER1"
     }


### PR DESCRIPTION
NB: events do not expose this NOMIS code because the entity & concept is likely to be removed (what is the status of a _group_ of reports anyway?)