### PR TITLE
IR-68: Expose polymorphic base type in swagger docs for sync payloads from NOMIS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/NomisSyncRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/NomisSyncRequest.kt
@@ -5,9 +5,13 @@ import jakarta.validation.ValidationException
 import uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis.NomisReport
 import java.util.UUID
 
+@Schema(description = "Incident report created or updated in NOMIS", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class NomisSyncRequest(
+  @get:Schema(description = "Incident report ID, required for updates and must be omitted for initial migration", requiredMode = Schema.RequiredMode.REQUIRED, example = "123e4567-e89b-12d3-a456-426614174000")
   val id: UUID? = null,
+  @get:Schema(description = "Set to true for initial migration, omit or set to false for updates", requiredMode = Schema.RequiredMode.REQUIRED, allowableValues = ["true"], example = "true")
   val initialMigration: Boolean = false,
+  @get:Schema(description = "Complete incident report payload", requiredMode = Schema.RequiredMode.REQUIRED)
   val incidentReport: NomisReport,
 ) {
   fun validate() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResource.kt
@@ -75,7 +75,7 @@ class NomisSyncResource(
     @Schema(
       description = "Incident report created/updated in NOMIS",
       accessMode = Schema.AccessMode.WRITE_ONLY,
-      oneOf = [NomisSyncCreateRequest::class, NomisSyncUpdateRequest::class],
+      oneOf = [NomisSyncRequest::class, NomisSyncCreateRequest::class, NomisSyncUpdateRequest::class],
     )
     @RequestBody
     @Valid


### PR DESCRIPTION
This is to make auto-generated code in `hmpps-prisoner-from-nomis-migration` simpler to use.