### PR TITLE
IR-954: Handle side effects of changing a report’s type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -187,9 +187,17 @@ class Report(
     changedAt: LocalDateTime,
     changedBy: String,
   ): Report {
-    copyToHistory(changedAt, changedBy)
-    questions.clear()
-    type = newType
+    if (type != newType) {
+      // archive existing questions and responses
+      copyToHistory(changedAt, changedBy)
+      // remove all questions and responses since new type will have a different set
+      questions.clear()
+      type = newType
+      // status is not changed, client applications should decide the new status
+      // remove all prisoner involvements because roles may not be allowed in new type
+      prisonersInvolved.clear()
+      // keep staff involvements because all roles are available in all types
+    }
     return this
   }
 
@@ -198,8 +206,10 @@ class Report(
     changedAt: LocalDateTime,
     changedBy: String,
   ): Report {
-    status = newStatus
-    addStatusHistory(newStatus, changedAt, changedBy)
+    if (status != newStatus) {
+      status = newStatus
+      addStatusHistory(newStatus, changedAt, changedBy)
+    }
     return this
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -263,6 +263,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
         ),
       )
     report.addStatusHistory(Status.DRAFT, now, "user5")
+    report.addStatusHistory(Status.AWAITING_ANALYSIS, now, "user1")
     report.addStaffInvolved(
       sequence = 0,
       staffUsername = "user1",
@@ -337,11 +338,11 @@ class ReportRepositoryTest : IntegrationTestBase() {
     assertThat(report.history.elementAt(2).questions).hasSize(3)
     assertThat(report.history.elementAt(2).questions.elementAt(1).responses).hasSize(2)
     assertThat(report.history.elementAt(2).questions.elementAt(1).responses.elementAt(1).response).isEqualTo("OTHER")
-    assertThat(report.historyOfStatuses).hasSize(1)
+    assertThat(report.historyOfStatuses).hasSize(2)
     assertThat(report.historyOfStatuses.elementAt(0).status).isEqualTo(Status.DRAFT)
+    assertThat(report.historyOfStatuses.elementAt(1).status).isEqualTo(Status.AWAITING_ANALYSIS)
     assertThat(report.staffInvolved).hasSize(1)
     assertThat(report.staffInvolved.elementAt(0).lastName).isEqualTo("Jones")
-    assertThat(report.prisonersInvolved).hasSize(1)
-    assertThat(report.prisonersInvolved.elementAt(0).lastName).isEqualTo("Smith")
+    assertThat(report.prisonersInvolved).isEmpty()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -1871,6 +1871,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             status = Status.AWAITING_ANALYSIS,
             generateQuestions = 2,
             generateResponses = 2,
+            generateStaffInvolvement = 1,
+            generatePrisonerInvolvement = 1,
             generateHistory = 0,
           ),
         )
@@ -1955,7 +1957,26 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                   ]
                 }
               ],
-              "questions": []
+              "questions": [],
+              "historyOfStatuses": [
+                {
+                  "status": "AWAITING_ANALYSIS",
+                  "nomisStatus": "AWAN",
+                  "changedAt": "2023-12-05T12:31:56",
+                  "changedBy": "USER1"
+                }
+              ],
+              "staffInvolved": [
+                {
+                  "staffUsername": "staff-1",
+                  "firstName": "First 1",
+                  "lastName": "Last 1",
+                  "staffRole": "AUTHORISING_OFFICER",
+                  "comment": "Comment #1",
+                  "sequence": 0
+                }
+              ],
+              "prisonersInvolved": []
             }
             """,
             JsonCompareMode.LENIENT,
@@ -1978,6 +1999,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             status = Status.AWAITING_ANALYSIS,
             generateQuestions = 1,
             generateResponses = 1,
+            generateStaffInvolvement = 1,
+            generatePrisonerInvolvement = 1,
             generateHistory = 1,
           ),
         )
@@ -2056,7 +2079,26 @@ class ReportResourceTest : SqsIntegrationTestBase() {
                   ]
                 }
               ],
-              "questions": []
+              "questions": [],
+              "historyOfStatuses": [
+                {
+                  "status": "AWAITING_ANALYSIS",
+                  "nomisStatus": "AWAN",
+                  "changedAt": "2023-12-05T12:31:56",
+                  "changedBy": "USER1"
+                }
+              ],
+              "staffInvolved": [
+                {
+                  "staffUsername": "staff-1",
+                  "firstName": "First 1",
+                  "lastName": "Last 1",
+                  "staffRole": "AUTHORISING_OFFICER",
+                  "comment": "Comment #1",
+                  "sequence": 0
+                }
+              ],
+              "prisonersInvolved": []
             }
             """,
             JsonCompareMode.LENIENT,


### PR DESCRIPTION
If a report’s type is changed, prisoner involvement roles could become invalid – all are now cleared.
API does not enforce rules around statuses, client applications should only change type when it is appropriate.