### PR TITLE
IR-562: Only replace prisoner numbers reported within a booking’s date range

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/IntegrationTestBase.kt
@@ -13,9 +13,10 @@ import java.time.ZoneId
 abstract class IntegrationTestBase {
 
   companion object {
+    val zoneId: ZoneId = ZoneId.of("Europe/London")
     val clock: Clock = Clock.fixed(
       Instant.parse("2023-12-05T12:34:56+00:00"),
-      ZoneId.of("Europe/London"),
+      zoneId,
     )
     val now: LocalDateTime = LocalDateTime.now(clock)
 


### PR DESCRIPTION
… when reacting to an event indicating that a booking was moved between two prisoner numbers. Previously, we incorrectly moved _all_ references to the moved prisoner number (not just that one booking).

This is now possible because the [`prison-offender-events.prisoner.booking.moved` domain event](https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/ministryofjustice/prison-offender-events/main/async-api.yml&readOnly#message-prison-offender-events.prisoner.booking.moved) includes the booking start date.