### PR TITLE
IR-68: Get Azure Application Insights settings from kubernetes secret directly

### DIFF
--- a/helm_deploy/hmpps-incident-reporting-api/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting-api/values.yaml
@@ -30,13 +30,14 @@ generic-service:
     JAVA_OPTS: "-Xmx512m"
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"
-    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_SQS_USE_WEB_TOKEN: "true"
 
   envFrom:
     - secretRef:
         name: hmpps-incident-reporting-api
+    - secretRef:
+        name: application-insights
 
   namespace_secrets:
     dps-rds-instance-output:


### PR DESCRIPTION
…the k8s secret itself is created by terraform from a shared DPS secret in a AWS systems manager parameter

Ref: [hmpps-template-kotlin#254](https://github.com/ministryofjustice/hmpps-template-kotlin/pull/254)