### PR TITLE
IR-686: Make question `code` field a unique identifier for questions within individual reports

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalQuestion.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "Previous question with responses making up a previous version of an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class HistoricalQuestion(
-  @Schema(description = "The question code")
+  @Schema(description = "The question code; used as a unique identifier within one report and typically refers to a specific question for an incident type")
   val code: String,
   @Schema(description = "The question text as seen by downstream data consumers")
   val question: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalResponse.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 @Schema(description = "Previous response to a question making up a previous version of an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class HistoricalResponse(
-  @Schema(description = "The response")
+  @Schema(description = "The response text as seen by downstream data consumers")
   val response: String,
   @Schema(description = "Optional response as a date", nullable = true, example = "2024-04-29")
   val responseDate: LocalDate? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Question.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "Question with responses making up an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class Question(
-  @Schema(description = "The question code")
+  @Schema(description = "The question code; used as a unique identifier within one report and typically refers to a specific question for an incident type")
   val code: String,
   @Schema(description = "The question text as seen by downstream data consumers")
   val question: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Response.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 @Schema(description = "Response to a question making up an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class Response(
-  @Schema(description = "The response")
+  @Schema(description = "The response text as seen by downstream data consumers")
   val response: String,
   @Schema(description = "Optional response as a date", nullable = true, example = "2024-04-29")
   val responseDate: LocalDate? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddOrUpdateQuestionWithResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddOrUpdateQuestionWithResponses.kt
@@ -5,9 +5,9 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 import java.time.LocalDate
 
-@Schema(description = "Payload to add question with responses to an incident report", accessMode = Schema.AccessMode.WRITE_ONLY)
-data class AddQuestionWithResponses(
-  @Schema(description = "The question code", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 60)
+@Schema(description = "Payload to add question with responses to an incident report or, if the question code exists in the report, update the question and overwrite responses", accessMode = Schema.AccessMode.WRITE_ONLY)
+data class AddOrUpdateQuestionWithResponses(
+  @Schema(description = "The question code; used as a unique identifier within one report", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, maxLength = 60)
   @field:Size(min = 1, max = 60)
   val code: String,
   @Schema(description = "The question text as seen by downstream data consumers", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
@@ -16,14 +16,14 @@ data class AddQuestionWithResponses(
   @Schema(description = "The responses to this question", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
   @field:Valid
   @field:Size(min = 1)
-  val responses: List<AddQuestionResponse>,
+  val responses: List<AddOrUpdateQuestionResponse>,
   @Schema(description = "Optional additional information", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null")
   val additionalInformation: String? = null,
 )
 
 @Schema(description = "A response to a question", accessMode = Schema.AccessMode.WRITE_ONLY)
-data class AddQuestionResponse(
-  @Schema(description = "The response", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
+data class AddOrUpdateQuestionResponse(
+  @Schema(description = "The response text as seen by downstream data consumers", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
   @field:Size(min = 1)
   val response: String,
   @Schema(description = "Optional response as a date", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true, defaultValue = "null", example = "2024-04-29")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
@@ -23,9 +23,20 @@ class HistoricalQuestion(
   @ManyToOne(fetch = FetchType.LAZY)
   val history: History,
 
-  // TODO: decide how this works and if it is ever unique (eg within 1 report)
+  /**
+   * Identifier that must be unique within one History item in a report; used for updating questions in place.
+   * Typically refers to a specific question for an incident type.
+   */
   val code: String,
+
+  /**
+   * The question text as seen by downstream data consumers
+   */
   val question: String,
+
+  /**
+   * Unused: could be a free-text response to a question
+   */
   val additionalInformation: String? = null,
 
   @OneToMany(mappedBy = "historicalQuestion", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
@@ -19,9 +19,21 @@ class HistoricalResponse(
   @ManyToOne(fetch = FetchType.LAZY)
   val historicalQuestion: HistoricalQuestion,
 
-  // TODO: should we add a `val code: String` like in Question?
+  // TODO: should we add a `val code: String` like in HistoricalQuestion?
+
+  /**
+   * The response text as seen by downstream data consumers
+   */
   val response: String,
+
+  /**
+   * Optional date attached to response
+   */
   val responseDate: LocalDate? = null,
+
+  /**
+   * Optional comment attached to response
+   */
   val additionalInformation: String? = null,
 
   val recordedBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
@@ -23,10 +23,21 @@ class Question(
   @ManyToOne(fetch = FetchType.LAZY)
   private val report: Report,
 
-  // TODO: decide how this works and if it is ever unique (eg within 1 report)
+  /**
+   * Identifier that must be unique within one report; used for updating questions in place.
+   * Typically refers to a specific question for an incident type.
+   */
   val code: String,
-  val question: String,
-  val additionalInformation: String? = null,
+
+  /**
+   * The question text as seen by downstream data consumers
+   */
+  var question: String,
+
+  /**
+   * Unused: could be a free-text response to a question
+   */
+  var additionalInformation: String? = null,
 
   @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @OrderColumn(name = "sequence", nullable = false)
@@ -40,6 +51,16 @@ class Question(
   fun getReport() = report
 
   fun getResponses(): List<Response> = responses
+
+  fun reset(
+    question: String,
+    additionalInformation: String? = null,
+  ): Question {
+    this.question = question
+    this.additionalInformation = additionalInformation
+    this.responses.clear()
+    return this
+  }
 
   fun addResponse(
     response: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
@@ -20,8 +20,20 @@ class Response(
   val question: Question,
 
   // TODO: should we add a `val code: String` like in Question?
+
+  /**
+   * The response text as seen by downstream data consumers
+   */
   val response: String,
+
+  /**
+   * Optional date attached to response
+   */
   val responseDate: LocalDate? = null,
+
+  /**
+   * Optional comment attached to response
+   */
   val additionalInformation: String? = null,
 
   val recordedBy: String,

--- a/src/main/resources/db/migration/V1_4__question_codes.sql
+++ b/src/main/resources/db/migration/V1_4__question_codes.sql
@@ -1,0 +1,5 @@
+-- enforces unique question codes within one report
+alter table question add constraint question_code_uniq unique (report_id, code);
+
+-- enforces unique historical question codes within one report’s history item
+alter table historical_question add constraint historical_question_code_uniq unique (history_id, code);

--- a/src/test/resources/questions-with-responses/add-and-update-request-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-and-update-request-with-responses.json
@@ -1,0 +1,29 @@
+[
+  {
+    "code": "1",
+    "question": "Updated question #1",
+    "additionalInformation": "Updated explanation #1",
+    "responses": [
+      {
+        "response": "New response #1",
+        "responseDate": "2023-11-30"
+      },
+      {
+        "response": "New response #2",
+        "additionalInformation": "Comment #1"
+      },
+      {
+        "response": "New response #3"
+      }
+    ]
+  },
+  {
+    "code": "2002",
+    "question": "Was anybody hurt?",
+    "responses": [
+      {
+        "response": "No"
+      }
+    ]
+  }
+]

--- a/src/test/resources/questions-with-responses/add-and-update-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-and-update-response-with-responses.json
@@ -1,0 +1,65 @@
+[
+  {
+    "code": "1",
+    "question": "Updated question #1",
+    "responses": [
+      {
+        "response": "New response #1",
+        "responseDate": "2023-11-30",
+        "additionalInformation": null,
+        "recordedBy": "request-user",
+        "recordedAt": "2023-12-05T12:34:56"
+      },
+      {
+        "response": "New response #2",
+        "responseDate": null,
+        "additionalInformation": "Comment #1",
+        "recordedBy": "request-user",
+        "recordedAt": "2023-12-05T12:34:56"
+      },
+      {
+        "response": "New response #3",
+        "responseDate": null,
+        "additionalInformation": null,
+        "recordedBy": "request-user",
+        "recordedAt": "2023-12-05T12:34:56"
+      }
+    ],
+    "additionalInformation": "Updated explanation #1"
+  },
+  {
+    "code": "2",
+    "question": "Question #2",
+    "responses": [
+      {
+        "response": "Response #1",
+        "responseDate": "2023-12-04",
+        "additionalInformation": "Prose #1",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56"
+      },
+      {
+        "response": "Response #2",
+        "responseDate": "2023-12-03",
+        "additionalInformation": "Prose #2",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56"
+      }
+    ],
+    "additionalInformation": "Explanation #2"
+  },
+  {
+    "code": "2002",
+    "question": "Was anybody hurt?",
+    "additionalInformation": null,
+    "responses": [
+      {
+        "response": "No",
+        "responseDate": null,
+        "additionalInformation": null,
+        "recordedBy": "request-user",
+        "recordedAt": "2023-12-05T12:34:56"
+      }
+    ]
+  }
+]

--- a/src/test/resources/questions-with-responses/update-request-with-responses.json
+++ b/src/test/resources/questions-with-responses/update-request-with-responses.json
@@ -1,0 +1,14 @@
+[
+  {
+    "code": "2",
+    "question": "Updated question #2",
+    "additionalInformation": "Updated explanation #2",
+    "responses": [
+      {
+        "response": "New response",
+        "responseDate": null,
+        "additionalInformation": null
+      }
+    ]
+  }
+]

--- a/src/test/resources/questions-with-responses/update-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/update-response-with-responses.json
@@ -1,0 +1,37 @@
+[
+  {
+    "code": "1",
+    "question": "Question #1",
+    "responses": [
+      {
+        "response": "Response #1",
+        "responseDate": "2023-12-04",
+        "additionalInformation": "Prose #1",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56"
+      },
+      {
+        "response": "Response #2",
+        "responseDate": "2023-12-03",
+        "additionalInformation": "Prose #2",
+        "recordedBy": "some-user",
+        "recordedAt": "2023-12-05T12:34:56"
+      }
+    ],
+    "additionalInformation": "Explanation #1"
+  },
+  {
+    "code": "2",
+    "question": "Updated question #2",
+    "responses": [
+      {
+        "response": "New response",
+        "responseDate": null,
+        "additionalInformation": null,
+        "recordedBy": "request-user",
+        "recordedAt": "2023-12-05T12:34:56"
+      }
+    ],
+    "additionalInformation": "Updated explanation #2"
+  }
+]


### PR DESCRIPTION
…so that:
1) questions can be updated in place (replacing all responses with new ones)
2) questions can be referenced directly and stably by the UI app

`/incident-reports/{reportId}/questions` endpoint now only accepts PUT requests and returns 200 CREATED.

New table constraints will take a long time to apply so should be run manually followed by
```sql
insert into flyway_schema_history (installed_rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success)
values (4, '1.4', 'question codes', 'SQL', 'V1_4__question_codes.sql', -1754573454, 'incident_reporting', now(), 0, true);
```