### PR TITLE
IR-696: Add database indices to speed up referencing questions by code

### DIFF
--- a/src/main/resources/db/migration/V1_5__question_code_index.sql
+++ b/src/main/resources/db/migration/V1_5__question_code_index.sql
@@ -1,0 +1,5 @@
+create index if not exists question_code_idx on question (code);
+create index if not exists question_report_and_code_idx on question (report_id, code);
+
+create index if not exists historical_question_code_idx on historical_question (code);
+create index if not exists historical_question_history_and_code_idx on historical_question (history_id, code);


### PR DESCRIPTION
Improves performance of changes in #220

NB: indices already created in all databases because it takes 120s+ and must be run manually. hence `if not exists` in the migration script.