### PR TITLE
IR-68: Rename domain event data classes to be a bit clearer

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonOffenderEventListener.kt
@@ -33,14 +33,14 @@ class PrisonOffenderEventListener(
 
     when (eventType) {
       PRISONER_MERGE_EVENT_TYPE -> {
-        val mergeEvent = mapper.readValue(message, HMPPSMergeDomainEvent::class.java)
+        val mergeEvent = mapper.readValue(message, HMPPSPrisonerMergeDomainEvent::class.java)
         reportService.replacePrisonerNumber(
           removedPrisonerNumber = mergeEvent.additionalInformation.removedNomsNumber,
           prisonerNumber = mergeEvent.additionalInformation.nomsNumber,
         )
       }
       PRISONER_BOOKING_MOVED_EVENT_TYPE -> {
-        val moveEvent = mapper.readValue(message, HMPPSMergeBookingMovedEvent::class.java)
+        val moveEvent = mapper.readValue(message, HMPPSBookingMovedDomainEvent::class.java)
         val additionalInformation = moveEvent.additionalInformation
         reportService.replacePrisonerNumberInDateRange(
           removedPrisonerNumber = additionalInformation.movedFromNomsNumber,
@@ -61,20 +61,20 @@ class PrisonOffenderEventListener(
   }
 }
 
-data class HMPPSMergeDomainEvent(
+data class HMPPSPrisonerMergeDomainEvent(
   val eventType: String? = null,
-  val additionalInformation: AdditionalInformationMerge,
+  val additionalInformation: AdditionalInformationPrisonerMerge,
   val version: String,
   val occurredAt: ZonedDateTime,
   val description: String,
 )
 
-data class AdditionalInformationMerge(
+data class AdditionalInformationPrisonerMerge(
   val nomsNumber: String,
   val removedNomsNumber: String,
 )
 
-data class HMPPSMergeBookingMovedEvent(
+data class HMPPSBookingMovedDomainEvent(
   val eventType: String? = null,
   val additionalInformation: AdditionalInformationBookingMoved,
   val version: String,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ spring:
         provider:
           hmpps-auth:
             token-uri: ${api.base.url.oauth}/oauth/token
+
   jackson:
     date-format: "yyyy-MM-dd'T'HH:mm:ssZ"
     serialization:


### PR DESCRIPTION
The “booking moved” one erroneously included “merge” in it's name and they both might as well be spelled out more clearly