### PR TITLE
Allow filtering list of basic reports by more than one incident type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/specifications/ReportSpecification.kt
@@ -18,7 +18,8 @@ fun filterBySource(informationSource: InformationSource) = Report::source.buildS
 fun filterByStatuses(statuses: Collection<Status>) = Report::status.buildSpecForIn(statuses)
 fun filterByStatuses(vararg statuses: Status) = filterByStatuses(statuses.toList())
 
-fun filterByType(type: Type) = Report::type.buildSpecForEqualTo(type)
+fun filterByTypes(types: Collection<Type>) = Report::type.buildSpecForIn(types)
+fun filterByTypes(vararg types: Type) = filterByTypes(types.toList())
 
 fun filterByIncidentDateFrom(date: LocalDate) =
   Report::incidentDateAndTime.buildSpecForGreaterThanOrEqualTo(date.atStartOfDay())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResource.kt
@@ -155,16 +155,20 @@ class ReportResource(
     )
     @RequestParam(required = false)
     status: List<Status>? = null,
-    @Schema(
-      description = "Filter by given incident type",
-      requiredMode = Schema.RequiredMode.NOT_REQUIRED,
-      nullable = true,
-      defaultValue = "null",
-      example = "DAMAGE",
-      implementation = Type::class,
+    @Parameter(
+      description = "Filter by given incident types (not type families)",
+      example = "[DAMAGE_1]",
+      array = ArraySchema(
+        schema = Schema(implementation = Type::class),
+        arraySchema = Schema(
+          requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+          nullable = true,
+          defaultValue = "null",
+        ),
+      ),
     )
     @RequestParam(required = false)
-    type: Type? = null,
+    type: List<Type>? = null,
     @Schema(
       description = "Filter for incidents occurring since this date (inclusive)",
       requiredMode = Schema.RequiredMode.NOT_REQUIRED,
@@ -248,7 +252,7 @@ class ReportResource(
       locations = locations,
       source = source,
       statuses = status ?: emptyList(),
-      type = type,
+      types = type ?: emptyList(),
       incidentDateFrom = incidentDateFrom,
       incidentDateUntil = incidentDateUntil,
       reportedDateFrom = reportedDateFrom,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -40,7 +40,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterB
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByReportedDateUntil
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterBySource
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByStatuses
-import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByType
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByTypes
 import uk.gov.justice.digital.hmpps.incidentreporting.resource.EventNotFoundException
 import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
 import java.time.Clock
@@ -70,7 +70,7 @@ class ReportService(
     locations: List<String> = emptyList(),
     source: InformationSource? = null,
     statuses: List<Status> = emptyList(),
-    type: Type? = null,
+    types: List<Type> = emptyList(),
     incidentDateFrom: LocalDate? = null,
     incidentDateUntil: LocalDate? = null,
     reportedDateFrom: LocalDate? = null,
@@ -90,7 +90,9 @@ class ReportService(
         if (statuses.isNotEmpty()) {
           add(filterByStatuses(statuses))
         }
-        type?.let { add(filterByType(type)) }
+        if (types.isNotEmpty()) {
+          add(filterByTypes(types))
+        }
         incidentDateFrom?.let { add(filterByIncidentDateFrom(incidentDateFrom)) }
         incidentDateUntil?.let { add(filterByIncidentDateUntil(incidentDateUntil)) }
         reportedDateFrom?.let { add(filterByReportedDateFrom(reportedDateFrom)) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -33,7 +33,7 @@ import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterB
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByReportedDateUntil
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterBySource
 import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByStatuses
-import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByType
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.specifications.filterByTypes
 import java.util.UUID
 
 @DisplayName("Report repository")
@@ -81,7 +81,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
         filterByLocations("MDI"),
         filterBySource(InformationSource.DPS),
         filterByStatuses(Status.DRAFT),
-        filterByType(Type.FIND_6),
+        filterByTypes(Type.FIND_6),
         filterByIncidentDateFrom(today.minusDays(2)),
         filterByIncidentDateUntil(today),
         filterByReportedDateFrom(today.minusDays(2)),
@@ -100,7 +100,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
         filterByLocations("LEI"),
         filterBySource(InformationSource.NOMIS),
         filterByStatuses(Status.AWAITING_ANALYSIS),
-        filterByType(Type.FOOD_REFUSAL_1),
+        filterByTypes(Type.FOOD_REFUSAL_1),
         filterByIncidentDateFrom(today),
         filterByIncidentDateUntil(today.minusDays(2)),
         filterByReportedDateFrom(today),
@@ -191,27 +191,27 @@ class ReportRepositoryTest : IntegrationTestBase() {
       assertSpecificationReturnsReports(
         filterByStatuses(Status.AWAITING_ANALYSIS)
           .and(filterBySource(InformationSource.DPS))
-          .and(filterByType(Type.FIND_6)),
+          .and(filterByTypes(Type.FIND_6)),
         listOf(report2Id),
       )
       assertSpecificationReturnsReports(
         filterByStatuses(Status.AWAITING_ANALYSIS)
           .and(filterByLocations("LEI"))
           .and(filterBySource(InformationSource.DPS))
-          .and(filterByType(Type.FIND_6)),
+          .and(filterByTypes(Type.FIND_6)),
         listOf(report2Id),
       )
       assertSpecificationReturnsReports(
         filterByStatuses(Status.AWAITING_ANALYSIS)
           .and(filterBySource(InformationSource.DPS))
           .and(filterByLocations("MDI"))
-          .and(filterByType(Type.FIND_6)),
+          .and(filterByTypes(Type.FIND_6)),
         emptyList(),
       )
       assertSpecificationReturnsReports(
         filterByIncidentDateFrom(today.minusDays(3))
           .and(filterByIncidentDateUntil(today.minusDays(3)))
-          .and(filterByType(Type.ASSAULT_5)),
+          .and(filterByTypes(Type.ASSAULT_5)),
         listOf(report1Id),
       )
       assertSpecificationReturnsReports(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -408,6 +408,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
             "source=DPS&location=MDI                                     | 1",
             "type=ASSAULT_5                                              | 0",
             "type=FIRE_1                                                 | 1",
+            "type=FIND_6,FIRE_1                                          | 5",
+            "type=FIND_6&type=FIRE_1                                     | 5",
             "type=FIRE_1&location=LEI                                    | 0",
             "type=FIRE_1&location=MDI                                    | 1",
             "incidentDateFrom=2023-12-05                                 | 1",


### PR DESCRIPTION
Apparently we could only filter by one at a time before; I forgot that