### PR TITLE
IR-887: Description addendums (data model)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/DescriptionAddendum.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/DescriptionAddendum.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "Addendum to the description", accessMode = Schema.AccessMode.READ_ONLY)
+@JsonInclude(JsonInclude.Include.ALWAYS)
+data class DescriptionAddendum(
+  @Schema(description = "Username of user who added this addendum", example = "USER_1")
+  val createdBy: String,
+  @Schema(description = "When addendum was added", example = "2024-04-29T12:34:56.789012")
+  val createdAt: LocalDateTime,
+  @Schema(description = "Addendum text")
+  val text: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/DescriptionAddendum.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/DescriptionAddendum.kt
@@ -11,6 +11,10 @@ data class DescriptionAddendum(
   val createdBy: String,
   @Schema(description = "When addendum was added", example = "2024-04-29T12:34:56.789012")
   val createdAt: LocalDateTime,
+  @Schema(description = "First name of person that added this addendum", example = "John")
+  val firstName: String,
+  @Schema(description = "Last name of person that added this addendum", example = "Doe")
+  val lastName: String,
   @Schema(description = "Addendum text")
   val text: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
@@ -18,7 +18,8 @@ class ReportWithDetails(
   location: String,
   title: String,
   description: String,
-  descriptionAddendums: List<DescriptionAddendum>,
+  @Schema(description = "Addendums to the description")
+  val descriptionAddendums: List<DescriptionAddendum>,
   reportedBy: String,
   reportedAt: LocalDateTime,
   status: Status,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
@@ -18,6 +18,7 @@ class ReportWithDetails(
   location: String,
   title: String,
   description: String,
+  descriptionAddendums: List<DescriptionAddendum>,
   reportedBy: String,
   reportedAt: LocalDateTime,
   status: Status,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/DescriptionAddendum.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/DescriptionAddendum.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.jpa
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import org.hibernate.Hibernate
+import uk.gov.justice.digital.hmpps.incidentreporting.jpa.helper.EntityOpen
+import java.time.LocalDateTime
+import uk.gov.justice.digital.hmpps.incidentreporting.dto.DescriptionAddendum as DescriptionAddendumDto
+
+@Entity
+@EntityOpen
+class DescriptionAddendum(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val id: Long? = null,
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  val report: Report,
+
+  val createdBy: String,
+  val createdAt: LocalDateTime,
+  val text: String,
+) : Comparable<DescriptionAddendum> {
+
+  companion object {
+    private val COMPARATOR = compareBy<DescriptionAddendum>
+      { it.report }
+      .thenBy { it.createdAt }
+      .thenBy { it.createdBy }
+      .thenBy { it.text }
+  }
+
+  override fun compareTo(other: DescriptionAddendum) = COMPARATOR.compare(this, other)
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+
+    other as DescriptionAddendum
+
+    if (report != other.report) return false
+    if (createdAt != other.createdAt) return false
+    if (createdBy != other.createdBy) return false
+    if (text != other.text) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = report.hashCode()
+    result = 31 * result + createdAt.hashCode() + createdBy.hashCode() + text.hashCode()
+    return result
+  }
+
+  override fun toString(): String {
+    return "DescriptionAddendum(id=$id, report=${report.reportReference}, " +
+      "createdBy=$createdBy, createdAt=$createdAt, text=$text)"
+  }
+
+  fun toDto() = DescriptionAddendumDto(
+    createdBy = createdBy,
+    createdAt = createdAt,
+    text = text,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/DescriptionAddendum.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/DescriptionAddendum.kt
@@ -22,6 +22,8 @@ class DescriptionAddendum(
   val report: Report,
 
   val createdBy: String,
+  val firstName: String,
+  val lastName: String,
   val createdAt: LocalDateTime,
   val text: String,
 ) : Comparable<DescriptionAddendum> {
@@ -31,6 +33,8 @@ class DescriptionAddendum(
       { it.report }
       .thenBy { it.createdAt }
       .thenBy { it.createdBy }
+      .thenBy { it.firstName }
+      .thenBy { it.lastName }
       .thenBy { it.text }
   }
 
@@ -45,6 +49,8 @@ class DescriptionAddendum(
     if (report != other.report) return false
     if (createdAt != other.createdAt) return false
     if (createdBy != other.createdBy) return false
+    if (firstName != other.firstName) return false
+    if (lastName != other.lastName) return false
     if (text != other.text) return false
 
     return true
@@ -52,17 +58,20 @@ class DescriptionAddendum(
 
   override fun hashCode(): Int {
     var result = report.hashCode()
-    result = 31 * result + createdAt.hashCode() + createdBy.hashCode() + text.hashCode()
+    result = 31 * result + createdAt.hashCode() + createdBy.hashCode()
+    result = 31 * result + firstName.hashCode() + lastName.hashCode() + text.hashCode()
     return result
   }
 
   override fun toString(): String {
     return "DescriptionAddendum(id=$id, report=${report.reportReference}, " +
-      "createdBy=$createdBy, createdAt=$createdAt, text=$text)"
+      "createdBy=$firstName $lastName, createdAt=$createdAt, text=$text)"
   }
 
   fun toDto() = DescriptionAddendumDto(
     createdBy = createdBy,
+    firstName = firstName,
+    lastName = lastName,
     createdAt = createdAt,
     text = text,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -219,12 +219,16 @@ class Report(
 
   fun appendToDescription(
     createdBy: String,
+    firstName: String,
+    lastName: String,
     createdAt: LocalDateTime,
     text: String,
   ): DescriptionAddendum {
     return DescriptionAddendum(
       report = this,
       createdBy = createdBy,
+      firstName = firstName,
+      lastName = lastName,
       createdAt = createdAt,
       text = text,
     ).also { descriptionAddendums.add(it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -45,6 +45,7 @@ import java.util.UUID
     NamedEntityGraph(
       name = "Report.eager",
       attributeNodes = [
+        NamedAttributeNode("descriptionAddendums"),
         NamedAttributeNode("event"),
         NamedAttributeNode("staffInvolved"),
         NamedAttributeNode("prisonersInvolved"),
@@ -111,6 +112,9 @@ class Report(
 
   var title: String,
   var description: String,
+  @OneToMany(mappedBy = "report", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @SortNatural
+  val descriptionAddendums: SortedSet<DescriptionAddendum> = sortedSetOf(),
 
   var reportedBy: String,
   var reportedAt: LocalDateTime,
@@ -211,6 +215,19 @@ class Report(
       addStatusHistory(newStatus, changedAt, changedBy)
     }
     return this
+  }
+
+  fun appendToDescription(
+    createdBy: String,
+    createdAt: LocalDateTime,
+    text: String,
+  ): DescriptionAddendum {
+    return DescriptionAddendum(
+      report = this,
+      createdBy = createdBy,
+      createdAt = createdAt,
+      text = text,
+    ).also { descriptionAddendums.add(it) }
   }
 
   fun addStatusHistory(
@@ -607,6 +624,7 @@ class Report(
     type = type,
     title = title,
     description = description,
+    descriptionAddendums = descriptionAddendums.map { it.toDto() },
     reportedBy = reportedBy,
     reportedAt = reportedAt,
     status = status,

--- a/src/main/resources/db/migration/V1_19__add_description_addendum.sql
+++ b/src/main/resources/db/migration/V1_19__add_description_addendum.sql
@@ -6,7 +6,9 @@ CREATE TABLE description_addendum
     CONSTRAINT description_addendum_report_fk REFERENCES report (id) ON DELETE CASCADE,
   "text"     TEXT         NOT NULL,
   created_at TIMESTAMP    NOT NULL,
-  created_by VARCHAR(120) NOT NULL
+  created_by VARCHAR(120) NOT NULL,
+  first_name VARCHAR(255) NOT NULL,
+  last_name  VARCHAR(255) NOT NULL
 );
 
 CREATE INDEX description_addendum_report_id_fk_idx on description_addendum (report_id);

--- a/src/main/resources/db/migration/V1_19__add_description_addendum.sql
+++ b/src/main/resources/db/migration/V1_19__add_description_addendum.sql
@@ -1,0 +1,13 @@
+CREATE TABLE description_addendum
+(
+  id                      SERIAL
+    CONSTRAINT description_addendum_pk PRIMARY KEY,
+  report_id               UUID         NOT NULL
+    CONSTRAINT description_addendum_report_fk REFERENCES report (id) ON DELETE CASCADE,
+  "text"     TEXT         NOT NULL,
+  created_at TIMESTAMP    NOT NULL,
+  created_by VARCHAR(120) NOT NULL
+);
+
+CREATE INDEX description_addendum_report_id_fk_idx on description_addendum (report_id);
+CREATE INDEX description_addendum_created_at_idx on description_addendum (created_at);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
@@ -57,6 +57,8 @@ fun buildReport(
   (1..generateDescriptionAddendums).forEach { addendumIndex ->
     report.appendToDescription(
       createdBy = "staff-$addendumIndex",
+      firstName = "First $addendumIndex",
+      lastName = "Last $addendumIndex",
       createdAt = reportTime,
       text = "Addendum #$addendumIndex",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
@@ -19,6 +19,7 @@ fun buildReport(
   type: Type = Type.FIND_6,
   reportingUsername: String = "USER1",
   // all related entities apart from event are optionally generated:
+  generateDescriptionAddendums: Int = 0,
   generateStaffInvolvement: Int = 0,
   generatePrisonerInvolvement: Int = 0,
   generateCorrections: Int = 0,
@@ -53,6 +54,13 @@ fun buildReport(
   )
   report.addStatusHistory(report.status, reportTime, reportingUsername)
 
+  (1..generateDescriptionAddendums).forEach { addendumIndex ->
+    report.appendToDescription(
+      createdBy = "staff-$addendumIndex",
+      createdAt = reportTime,
+      text = "Addendum #$addendumIndex",
+    )
+  }
   (1..generateStaffInvolvement).forEach { staffIndex ->
     report.addStaffInvolved(
       sequence = staffIndex - 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -328,14 +328,14 @@ class ReportRepositoryTest : IntegrationTestBase() {
       "John",
       "Doe",
       now,
-      "The prisoner was admitted to hospital"
+      "The prisoner was admitted to hospital",
     )
     report.appendToDescription(
       "SOME_USER_2",
       "Jane",
       "Doe",
       now,
-      "The prisoner was discharged from hospital"
+      "The prisoner was discharged from hospital",
     )
 
     TestTransaction.flagForCommit()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -323,6 +323,9 @@ class ReportRepositoryTest : IntegrationTestBase() {
       .addResponse("MAYBE", null, 2, "Maybe", "user1", now)
       .addResponse("OTHER", null, 3, "Other", "user1", now)
 
+    report.appendToDescription("SOME_USER_1", now, "The prisoner was admitted to hospital")
+    report.appendToDescription("SOME_USER_2", now, "The prisoner was discharged from hospital")
+
     TestTransaction.flagForCommit()
     TestTransaction.end()
     TestTransaction.start()
@@ -331,6 +334,12 @@ class ReportRepositoryTest : IntegrationTestBase() {
       ?: throw EntityNotFoundException()
     assertThat(report.status).isEqualTo(Status.AWAITING_ANALYSIS)
     assertThat(report.type).isEqualTo(Type.ASSAULT_5)
+    assertThat(report.description).isEqualTo("An incident occurred")
+    assertThat(report.descriptionAddendums).hasSize(2)
+    assertThat(report.descriptionAddendums.elementAt(0).createdBy).isEqualTo("SOME_USER_1")
+    assertThat(report.descriptionAddendums.elementAt(0).text).isEqualTo("The prisoner was admitted to hospital")
+    assertThat(report.descriptionAddendums.elementAt(1).createdBy).isEqualTo("SOME_USER_2")
+    assertThat(report.descriptionAddendums.elementAt(1).text).isEqualTo("The prisoner was discharged from hospital")
     assertThat(report.questions).hasSize(1)
     assertThat(report.questions.elementAt(0).code).isEqualTo("SOME_QUESTION")
     assertThat(report.questions.elementAt(0).responses).hasSize(4)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -323,8 +323,20 @@ class ReportRepositoryTest : IntegrationTestBase() {
       .addResponse("MAYBE", null, 2, "Maybe", "user1", now)
       .addResponse("OTHER", null, 3, "Other", "user1", now)
 
-    report.appendToDescription("SOME_USER_1", now, "The prisoner was admitted to hospital")
-    report.appendToDescription("SOME_USER_2", now, "The prisoner was discharged from hospital")
+    report.appendToDescription(
+      "SOME_USER_1",
+      "John",
+      "Doe",
+      now,
+      "The prisoner was admitted to hospital"
+    )
+    report.appendToDescription(
+      "SOME_USER_2",
+      "Jane",
+      "Doe",
+      now,
+      "The prisoner was discharged from hospital"
+    )
 
     TestTransaction.flagForCommit()
     TestTransaction.end()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -1290,6 +1290,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                 "prisonId": "FBI",
                 "title": "Updated title",
                 "description": "Updated details",
+                "descriptionAddendums": [],
                 "event": {
                   "id": "${existingNomisReport.event.id}",
                   "eventReference": "$NOMIS_INCIDENT_NUMBER",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -577,11 +577,15 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "descriptionAddendums": [
                 {
                   "createdBy": "staff-1",
+                  "firstName": "First 1",
+                  "lastName": "Last 1",
                   "createdAt": "2023-12-05T12:34:56",
                   "text": "Addendum #1"
                 },
                 {
                   "createdBy": "staff-2",
+                  "firstName": "First 2",
+                  "lastName": "Last 2",
                   "createdAt": "2023-12-05T12:34:56",
                   "text": "Addendum #2"
                 }
@@ -764,11 +768,15 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "descriptionAddendums": [
                 {
                   "createdBy": "staff-1",
+                  "firstName": "First 1",
+                  "lastName": "Last 1",
                   "createdAt": "2023-12-05T12:34:56",
                   "text": "Addendum #1"
                 },
                 {
                   "createdBy": "staff-2",
+                  "firstName": "First 2",
+                  "lastName": "Last 2",
                   "createdAt": "2023-12-05T12:34:56",
                   "text": "Addendum #2"
                 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -75,6 +75,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
       buildReport(
         reportReference = "11124143",
         reportTime = now,
+        generateDescriptionAddendums = 2,
       ),
     )
   }
@@ -573,6 +574,18 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "prisonId": "MDI",
               "title": "Incident Report 11124143",
               "description": "A new incident created in the new service of type find of illicit items",
+              "descriptionAddendums": [
+                {
+                  "createdBy": "staff-1",
+                  "createdAt": "2023-12-05T12:34:56",
+                  "text": "Addendum #1"
+                },
+                {
+                  "createdBy": "staff-2",
+                  "createdAt": "2023-12-05T12:34:56",
+                  "text": "Addendum #2"
+                }
+              ],
               "event": {
                 "id": "${existingReport.event.id}",
                 "eventReference": "11124143",
@@ -748,6 +761,18 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "prisonId": "MDI",
               "title": "Incident Report 11124143",
               "description": "A new incident created in the new service of type find of illicit items",
+              "descriptionAddendums": [
+                {
+                  "createdBy": "staff-1",
+                  "createdAt": "2023-12-05T12:34:56",
+                  "text": "Addendum #1"
+                },
+                {
+                  "createdBy": "staff-2",
+                  "createdAt": "2023-12-05T12:34:56",
+                  "text": "Addendum #2"
+                }
+              ],
               "event": {
                 "id": "${existingReport.event.id}",
                 "eventReference": "11124143",


### PR DESCRIPTION
- a report can have many description addendums (text appended to the description by a user)
- added `description_addendum` table to contain these records
- endpoints returning a `ReportWithDetails` response will include these description addendums (while basic report will not as they don't include these kind of related objects, for performance reasons)
- this should not be a breaking change

NOTE: This is the foundation for other parts of this work, e.g. an endpoint to create these description addendums, but these will be part of separate PRs.