### PR TITLE
IR-1008 Update refresh-views-cronjob.yaml to adjust non-production schedule to 19:00 and exclude pre-prod

### DIFF
--- a/helm_deploy/hmpps-incident-reporting-api/templates/refresh-views-cronjob.yaml
+++ b/helm_deploy/hmpps-incident-reporting-api/templates/refresh-views-cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.environment.name "prod") (eq .Values.environment.name "dev") }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -6,7 +7,7 @@ spec:
   {{- if (eq .Values.environment.name "prod") }}
   schedule: "00 03 * * *"
   {{- else }}
-  schedule: "00 20 * * 1-5"
+  schedule: "00 19 * * 1-5"
   {{- end }}
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5
@@ -33,3 +34,4 @@ spec:
                 seccompProfile:
                   type: RuntimeDefault
           restartPolicy: Never
+{{- end }}


### PR DESCRIPTION
This Pull Request (PR) updates the configuration for the refresh-views-cronjob in the hmpps-incident-reporting-api Helm deployment template. The changes introduce environment-specific conditions and modify the cronjob schedule for non-production environments.
### Main Changes
- Added conditional logic to include the cronjob definition only for environments prod and dev.
- Adjusted the schedule for non-production environments to run at 19:00 instead of 20:00.
- Ensured the cronjob definition is enclosed within the new conditional block to avoid unnecessary deployment in other environments.