### PR TITLE
IR-1040: Removed `INCIDENT_UPDATED` status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
@@ -22,9 +22,8 @@ enum class Status(
   UPDATED("Updated", "INAME"),
   CLOSED("Closed", "CLOSE"),
 
-  // TODO: POST_INCIDENT_UPDATE/INCIDENT_UPDATED will be removed
+  // TODO: POST_INCIDENT_UPDATE will be removed
   POST_INCIDENT_UPDATE("Post-incident update", "PIU"),
-  INCIDENT_UPDATED("Incident updated", "IUP"),
 
   DUPLICATE("Duplicate", "DUP"),
   NOT_REPORTABLE("Not reportable", null),

--- a/src/main/resources/db/migration/V1_22__delete_incident_updated_status.sql
+++ b/src/main/resources/db/migration/V1_22__delete_incident_updated_status.sql
@@ -1,0 +1,6 @@
+-- Removes INCIDENT_UPDATED status
+-- See: https://dsdmoj.atlassian.net/wiki/spaces/IR/pages/5589893167/Status+old+and+new
+
+DELETE FROM constant_status
+WHERE code = 'INCIDENT_UPDATED';
+


### PR DESCRIPTION
Mike said occurrences have been removed from all
systems, including NOMIS. I checked `preprod` DB
and I didn't see any rows in `report` or `status_history` tables with this status.