### PR TITLE
IR-1068 Add SCHEMA_TO_RESTORE variable for selective database restoration

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -24,6 +24,8 @@ generic-service:
 
   postgresDatabaseRestore:
     enabled: true
+    env:
+      SCHEMA_TO_RESTORE: "public"
     namespace_secrets:
       dps-rds-instance-output:
         DB_NAME: "database_name"


### PR DESCRIPTION
```
### Description

This pull request introduces an environment variable `SCHEMA_TO_RESTORE` to control schema restoration during database recovery. Specifically, the updates enable only the `public` schema to be restored while excluding the `report` schema.


```