### PR TITLE
IR-1094: Accept moment NOMIS’ requirement was recorded as a datetime using new field only

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/NomisRequirement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/nomis/NomisRequirement.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.incidentreporting.dto.nomis
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -11,11 +10,8 @@ data class NomisRequirement(
   val sequence: Int,
   @Schema(description = "The update required to the incident report")
   val comment: String?,
-  @Schema(description = "Date the requirement was recorded", deprecated = true)
-  val date: LocalDate,
-  // TODO: will become non-optional once all environments are migrated
   @Schema(description = "Date and time the requirement was recorded")
-  val recordedDate: LocalDateTime?,
+  val recordedDate: LocalDateTime,
   @Schema(description = "The staff member who made the requirement request")
   val staff: NomisStaff,
   @Schema(description = "The reporting location of the staff")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -431,7 +431,7 @@ class Report(
     report = this,
     sequence = nomisRequirement.sequence,
     correctionRequestedBy = nomisRequirement.staff.username,
-    correctionRequestedAt = nomisRequirement.recordedDate ?: nomisRequirement.date.atStartOfDay(),
+    correctionRequestedAt = nomisRequirement.recordedDate,
     descriptionOfChange = nomisRequirement.comment ?: NO_DETAILS_GIVEN,
     location = nomisRequirement.prisonId,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -130,7 +130,6 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
           NomisRequirement(
             sequence = 0,
             comment = "Change 1",
-            date = today,
             recordedDate = now,
             staff = reportingStaff,
             prisonId = "MDI",
@@ -140,7 +139,6 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
           NomisRequirement(
             sequence = 1,
             comment = "Change 2",
-            date = today.minusWeeks(1),
             recordedDate = now.minusWeeks(1),
             staff = reportingStaff,
             prisonId = "MDI",
@@ -1415,7 +1413,6 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               NomisRequirement(
                 sequence = 0,
                 comment = "Could you update the title please",
-                date = today.minusWeeks(1),
                 recordedDate = now.minusWeeks(1),
                 staff = reportingStaff,
                 prisonId = "MDI",
@@ -1425,7 +1422,6 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
               NomisRequirement(
                 sequence = 1,
                 comment = "Also the description",
-                date = today,
                 recordedDate = now,
                 staff = reportingStaff,
                 prisonId = "MDI",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
@@ -109,7 +109,6 @@ class NomisSyncServiceTest {
         NomisRequirement(
           sequence = 0,
           comment = "Title should include prisoner number",
-          date = today,
           recordedDate = now,
           prisonId = "MDI",
           staff = NomisStaff(

--- a/src/test/resources/nomis-sync/sample-report.json
+++ b/src/test/resources/nomis-sync/sample-report.json
@@ -106,7 +106,6 @@
     {
       "sequence": 0,
       "comment": "Type should be assault",
-      "date": "2024-01-20",
       "recordedDate": "2024-01-20T09:10:20",
       "staff": {
         "username": "user2",
@@ -121,7 +120,6 @@
     {
       "sequence": 1,
       "comment": "Add details to description",
-      "date": "2024-01-21",
       "recordedDate": "2024-01-21T11:20:30",
       "staff": {
         "username": "user2",


### PR DESCRIPTION
#342 and NOMIS side have been deployed in all environments so can proceed…

Refer:
- [hmpps-nomis-prisoner-api#1214](https://github.com/ministryofjustice/hmpps-nomis-prisoner-api/pull/1214)
- [hmpps-prisoner-from-nomis-migration#1450](https://github.com/ministryofjustice/hmpps-prisoner-from-nomis-migration/pull/1450)