### PR TITLE
IR-1098 Add `code` field to responses.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/HistoricalResponse.kt
@@ -11,6 +11,8 @@ import java.time.LocalDateTime
 )
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class HistoricalResponse(
+  @Schema(description = "Unique identifier for a response to a question", nullable = true)
+  val code: String?,
   @Schema(description = "The response text as seen by downstream data consumers")
   val response: String,
   // TODO: sequences are only being exposed while we sort out sync problems: they do not need to remain in the api contract

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/Response.kt
@@ -8,6 +8,8 @@ import java.time.LocalDateTime
 @Schema(description = "Response to a question making up an incident report", accessMode = Schema.AccessMode.READ_ONLY)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class Response(
+  @Schema(description = "Unique identifier for a response to a question", nullable = true)
+  val code: String?,
   @Schema(description = "The response text as seen by downstream data consumers")
   val response: String,
   // TODO: sequences are only being exposed while we sort out sync problems: they do not need to remain in the api contract

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddOrUpdateQuestionWithResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddOrUpdateQuestionWithResponses.kt
@@ -41,6 +41,15 @@ data class AddOrUpdateQuestionWithResponses(
 
 @Schema(description = "A response to a question", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class AddOrUpdateQuestionResponse(
+  // TODO: WARNING will overwrite any existing response code if null.  This will change once we have the code as mandatory
+  @Schema(
+    description = "The response code; used as a unique identifier within one report",
+    requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    minLength = 1,
+    maxLength = 60,
+  )
+  @field:Size(min = 1, max = 60)
+  val code: String? = null,
   @Schema(
     description = "The response text as seen by downstream data consumers",
     requiredMode = Schema.RequiredMode.REQUIRED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
@@ -104,6 +104,7 @@ class HistoricalQuestion(
     nomisResponse.answer?.let {
       HistoricalResponse(
         historicalQuestion = this,
+        code = nomisResponse.questionResponseId.toString(),
         response = it,
         sequence = nomisResponse.responseSequence,
         responseDate = nomisResponse.responseDate,
@@ -119,6 +120,7 @@ class HistoricalQuestion(
   }
 
   fun addResponse(
+    code: String?,
     response: String,
     sequence: Int,
     responseDate: LocalDate? = null,
@@ -129,6 +131,7 @@ class HistoricalQuestion(
     addResponse(
       HistoricalResponse(
         historicalQuestion = this,
+        code = code,
         response = response,
         sequence = sequence,
         responseDate = responseDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
@@ -22,7 +22,8 @@ class HistoricalResponse(
   @ManyToOne(fetch = FetchType.LAZY)
   val historicalQuestion: HistoricalQuestion,
 
-  // TODO: should we add a `val code: String` like in HistoricalQuestion?
+  // TODO: remove nullable once migrated.
+  val code: String?,
 
   val sequence: Int,
 
@@ -48,7 +49,7 @@ class HistoricalResponse(
   companion object {
     private val COMPARATOR = compareBy<HistoricalResponse>
       { it.historicalQuestion }
-      .thenBy { it.sequence }
+      .thenBy { it.sequence } // TODO: replace with code once not nullable
   }
 
   override fun compareTo(other: HistoricalResponse) = COMPARATOR.compare(this, other)
@@ -77,6 +78,7 @@ class HistoricalResponse(
   }
 
   fun toDto() = HistoricalResponseDto(
+    code = code,
     response = response,
     sequence = sequence,
     responseDate = responseDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
@@ -111,6 +111,7 @@ class Question(
   fun createResponse(nomisResponse: NomisResponse, recordedAt: LocalDateTime): Response? = nomisResponse.answer?.let {
     Response(
       question = this,
+      code = nomisResponse.questionResponseId.toString(),
       response = it,
       sequence = nomisResponse.sequence,
       responseDate = nomisResponse.responseDate,
@@ -126,6 +127,7 @@ class Question(
   }
 
   fun addResponse(
+    code: String?,
     response: String,
     responseDate: LocalDate? = null,
     sequence: Int,
@@ -136,6 +138,7 @@ class Question(
     addResponse(
       Response(
         question = this,
+        code = code,
         response = response,
         sequence = sequence,
         responseDate = responseDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -578,6 +578,7 @@ class Report(
       )
       question.responses.forEach { response ->
         historicalQuestion.addResponse(
+          code = response.code,
           response = response.response,
           sequence = response.sequence,
           responseDate = response.responseDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
@@ -22,7 +22,11 @@ class Response(
   @ManyToOne(fetch = FetchType.LAZY)
   val question: Question,
 
-  // TODO: should we add a `val code: String` like in Question?
+  /**
+   * Identifier that refers to a specific answer for an incident type.
+   * TODO: remove nullable once migrated.
+   */
+  val code: String?,
 
   val sequence: Int,
 
@@ -48,7 +52,7 @@ class Response(
   companion object {
     private val COMPARATOR = compareBy<Response>
       { it.question }
-      .thenBy { it.sequence }
+      .thenBy { it.sequence } // TODO: replace with code once not nullable
   }
 
   override fun compareTo(other: Response) = COMPARATOR.compare(this, other)
@@ -72,10 +76,11 @@ class Response(
   }
 
   override fun toString(): String {
-    return "Response(id=$id, questionId=${question.id}, sequence=$sequence, response=$response)"
+    return "Response(id=$id, questionId=${question.id}, code=$code, sequence=$sequence, response=$response)"
   }
 
   fun toDto() = ResponseDto(
+    code = code,
     response = response,
     sequence = sequence,
     responseDate = responseDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/ReportService.kt
@@ -326,6 +326,7 @@ class ReportService(
           var sequence = if (this.responses.isEmpty()) 0 else this.responses.last().sequence + 1
           request.responses.forEach {
             addResponse(
+              code = it.code,
               response = it.response,
               sequence = sequence,
               responseDate = it.responseDate,

--- a/src/main/resources/db/migration/V1_23__add_code_column_to_responses.sql
+++ b/src/main/resources/db/migration/V1_23__add_code_column_to_responses.sql
@@ -1,0 +1,4 @@
+ALTER TABLE response ADD COLUMN code VARCHAR(60);
+ALTER TABLE historical_response ADD COLUMN code VARCHAR(60);
+
+CREATE INDEX response_code_idx on response (question_id, code);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
@@ -106,6 +106,7 @@ fun buildReport(
     )
     (1..generateResponses).forEach { responseIndex ->
       question.addResponse(
+        code = "$questionIndex-$responseIndex",
         response = "Response #$responseIndex",
         sequence = responseIndex - 1,
         responseDate = eventDateAndTime.toLocalDate().minusDays(responseIndex.toLong()),
@@ -131,6 +132,7 @@ fun buildReport(
       )
       (1..generateResponses).forEach { responseIndex ->
         historicalQuestion.addResponse(
+          code = "#$historyIndex-$responseIndex",
           response = "Historical response #$historyIndex-$responseIndex",
           responseDate = eventDateAndTime.toLocalDate().minusDays(responseIndex.toLong()),
           additionalInformation = "Prose #$responseIndex in history #$historyIndex",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -309,7 +309,7 @@ class ReportRepositoryTest : IntegrationTestBase() {
       .addResponse("OCCUR_CELL", "CELL", null, 1, "In the cell", "user1", now)
 
     report.addQuestion("METHOD", "Method Used to hurt themselves?", 2)
-      .addResponse(" METHOD_KNIFE", "KNIFE", null, 0, "They used a knife", "user1", now)
+      .addResponse("METHOD_KNIFE", "KNIFE", null, 0, "They used a knife", "user1", now)
       .addResponse("METHOD_OTHER", "OTHER", null, 1, "They used something else", "user1", now)
 
     report.addQuestion("BLAH", "Blah?", 3)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ReportRepositoryTest.kt
@@ -305,27 +305,27 @@ class ReportRepositoryTest : IntegrationTestBase() {
       ?: throw EntityNotFoundException()
 
     report.addQuestion("WHERE_OCCURRED", "Where did this occur?", 1)
-      .addResponse("DETOX_UNIT", null, 0, "They hurt themselves", "user1", now)
-      .addResponse("CELL", null, 1, "In the cell", "user1", now)
+      .addResponse("OCCUR_DETOX", "DETOX_UNIT", null, 0, "They hurt themselves", "user1", now)
+      .addResponse("OCCUR_CELL", "CELL", null, 1, "In the cell", "user1", now)
 
     report.addQuestion("METHOD", "Method Used to hurt themselves?", 2)
-      .addResponse("KNIFE", null, 0, "They used a knife", "user1", now)
-      .addResponse("OTHER", null, 1, "They used something else", "user1", now)
+      .addResponse(" METHOD_KNIFE", "KNIFE", null, 0, "They used a knife", "user1", now)
+      .addResponse("METHOD_OTHER", "OTHER", null, 1, "They used something else", "user1", now)
 
     report.addQuestion("BLAH", "Blah?", 3)
-      .addResponse("HEAD", null, 0, "Head", "user1", now)
-      .addResponse("ARM", null, 1, "Arm", "user1", now)
+      .addResponse("BLAH_HEAD", "HEAD", null, 0, "Head", "user1", now)
+      .addResponse("BLAH_ARM", "ARM", null, 1, "Arm", "user1", now)
 
     report.addHistory(Type.FIND_6, halfHourAgo, "user2")
       .addQuestion("FINDS-Q1", "Finds question 1", 1)
-      .addResponse("response1", 0, null, "Some information 1", "user1", halfHourAgo)
-      .addResponse("response2", 1, null, "Some information 2", "user1", halfHourAgo)
-      .addResponse("response3", 2, null, "Some information 3", "user1", halfHourAgo)
+      .addResponse("FINDS-Q1-R1", "response1", 0, null, "Some information 1", "user1", halfHourAgo)
+      .addResponse("FINDS-Q1-R2", "response2", 1, null, "Some information 2", "user1", halfHourAgo)
+      .addResponse("FINDS-Q1-R3", "response3", 2, null, "Some information 3", "user1", halfHourAgo)
 
     report.addHistory(Type.ASSAULT_5, quarterHourAgo, "user1")
       .addQuestion("ASSAULT-Q1", "Assault question 1", 1)
-      .addResponse("response4", 0, null, "Some information 4", "user1", quarterHourAgo)
-      .addResponse("response5", 1, null, "Some information 5", "user1", quarterHourAgo)
+      .addResponse("ASSAULT-Q1-R4", "response4", 0, null, "Some information 4", "user1", quarterHourAgo)
+      .addResponse("ASSAULT-Q1-R5", "response5", 1, null, "Some information 5", "user1", quarterHourAgo)
 
     TestTransaction.flagForCommit()
     TestTransaction.end()
@@ -336,10 +336,10 @@ class ReportRepositoryTest : IntegrationTestBase() {
     report.changeType(Type.ASSAULT_5, now, "user5")
 
     report.addQuestion("SOME_QUESTION", "Another question?", 4)
-      .addResponse("YES", null, 0, "Yes", "user1", now)
-      .addResponse("NO", null, 1, "No", "user1", now)
-      .addResponse("MAYBE", null, 2, "Maybe", "user1", now)
-      .addResponse("OTHER", null, 3, "Other", "user1", now)
+      .addResponse("SOME_QUESTION_YES", "YES", null, 0, "Yes", "user1", now)
+      .addResponse("SOME_QUESTION_NO", "NO", null, 1, "No", "user1", now)
+      .addResponse("SOME_QUESTION_MAYBE", "MAYBE", null, 2, "Maybe", "user1", now)
+      .addResponse("SOME_QUESTION_OTHER", "OTHER", null, 3, "Other", "user1", now)
 
     TestTransaction.flagForCommit()
     TestTransaction.end()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/DprReportingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/DprReportingIntegrationTest.kt
@@ -540,6 +540,7 @@ class DprReportingIntegrationTest : SqsIntegrationTestBase() {
             question = "WHERE DID THE INCIDENT TAKE PLACE",
             1,
           ).addResponse(
+            code = "WHERE_CELL",
             response = "CELL",
             additionalInformation = "H1",
             sequence = 0,
@@ -550,17 +551,17 @@ class DprReportingIntegrationTest : SqsIntegrationTestBase() {
             code = "1",
             question = "DID SELF HARM METHOD INVOLVE CUTTING",
             2,
-          ).addResponse(response = "YES", sequence = 0, recordedBy = "staff-1", recordedAt = now)
+          ).addResponse(code = "WHERE_CELL", response = "YES", sequence = 0, recordedBy = "staff-1", recordedAt = now)
           selfHarm.addQuestion(
             code = "1",
             question = "TYPE OF IMPLEMENT USED",
             3,
-          ).addResponse(response = "Knife", sequence = 0, recordedBy = "staff-1", recordedAt = now)
+          ).addResponse(code = "TYPE_KNIFE", response = "Knife", sequence = 0, recordedBy = "staff-1", recordedAt = now)
           selfHarm.addQuestion(
             code = "1",
             question = "WHAT OTHER METHOD OF SELF HARM WAS INVOLVED",
             4,
-          ).addResponse(response = "Mirror", sequence = 0, recordedBy = "staff-1", recordedAt = now)
+          ).addResponse(code = "SM_MIRROR", response = "Mirror", sequence = 0, recordedBy = "staff-1", recordedAt = now)
 
           reportRepository.saveAndFlush(selfHarm)
 
@@ -811,7 +812,7 @@ class DprReportingIntegrationTest : SqsIntegrationTestBase() {
             code = "1",
             question = "WAS A SERIOUS INJURY SUSTAINED",
             1,
-          ).addResponse(response = "YES", sequence = 0, recordedBy = "staff-1", recordedAt = now)
+          ).addResponse(code = "SERIOUS_YES", response = "YES", sequence = 0, recordedBy = "staff-1", recordedAt = now)
 
           reportRepository.saveAndFlush(violence)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/NomisSyncResourceTest.kt
@@ -1643,6 +1643,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "sequence": 1,
                     "responses": [
                       {
+                        "code": "10",
                         "response": "John",
                         "sequence": 0,
                         "responseDate": "2023-12-03",
@@ -1651,6 +1652,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "recordedAt": "2023-12-04T12:34:56"
                       },
                       {
+                        "code": "11",
                         "response": "Trevor",
                         "sequence": 1,
                         "responseDate": null,
@@ -1659,6 +1661,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "recordedAt": "2023-12-04T12:34:56"
                       },
                       {
+                        "code": "12",
                         "response": "Maybe someone else?",
                         "sequence": 2,
                         "responseDate": "2023-12-02",
@@ -1675,6 +1678,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                     "sequence": 2,
                     "responses": [
                       {
+                        "code": "13",
                         "response": "Cell",
                         "sequence": 0,
                         "responseDate": "2023-12-04",
@@ -1683,6 +1687,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "recordedAt": "2023-12-04T12:34:56"
                       },
                       {
+                        "code": "14",
                         "response": "Landing",
                         "sequence": 1,
                         "responseDate": null,
@@ -1691,6 +1696,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "recordedAt": "2023-12-04T12:34:56"
                       },
                       {
+                        "code": "15",
                         "response": "Kitchen",
                         "sequence": 2,
                         "responseDate": "2023-11-25",
@@ -1699,6 +1705,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "recordedAt": "2023-12-04T12:34:56"
                       },
                       {
+                        "code": "16",
                         "response": "Exercise area",
                         "sequence": 3,
                         "responseDate": null,
@@ -1723,6 +1730,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "sequence": 1,
                         "responses": [
                           {
+                            "code": "1",
                             "response": "Old answer 1",
                             "sequence": 0,
                             "responseDate": "2023-12-05",
@@ -1731,6 +1739,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                             "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
+                            "code": "2",
                             "response": "Old answer 2",
                             "sequence": 1,
                             "responseDate": null,
@@ -1739,6 +1748,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                             "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
+                            "code": "3",
                             "response": "Old answer 3",
                             "sequence": 2,
                             "responseDate": "2023-11-28",
@@ -1755,6 +1765,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "sequence": 2,
                         "responses": [
                           {
+                            "code": "4",
                             "response": "Old answer 4",
                             "sequence": 0,
                             "responseDate": "2023-12-04",
@@ -1763,6 +1774,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                             "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
+                            "code": "5",
                             "response": "Old answer 5",
                             "sequence": 1,
                             "responseDate": null,
@@ -1771,6 +1783,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                             "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
+                            "code": "6",
                             "response": "Old answer 6",
                             "sequence": 2,
                             "responseDate": "2023-11-27",
@@ -1795,6 +1808,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "sequence": 1,
                         "responses": [
                           {
+                            "code": "12",
                             "response": "Old old answer 1",
                             "sequence": 0,
                             "responseDate": null,
@@ -1803,6 +1817,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                             "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
+                            "code": "22",
                             "response": "Old old answer 2",
                             "sequence": 1,
                             "responseDate": null,
@@ -1819,6 +1834,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                         "sequence": 2,
                         "responses": [
                           {
+                            "code": "44",
                             "response": "Old old answer 1",
                             "sequence": 0,
                             "responseDate": null,
@@ -1827,6 +1843,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
                             "recordedAt": "2023-12-04T12:34:56"
                           },
                           {
+                            "code": "55",
                             "response": "Old old answer 2",
                             "sequence": 1,
                             "responseDate": null,
@@ -1943,6 +1960,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         val q3 = newReport.addQuestion(code = "3", sequence = 3, question = "Q3")
 
         q1.addResponse(
+          code = "Q1-R1",
           response = "Q1-R1",
           responseDate = today,
           sequence = 0,
@@ -1952,6 +1970,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         )
 
         q1.addResponse(
+          code = "Q1-R2",
           response = "Q1-R2",
           responseDate = today,
           sequence = 1,
@@ -1961,6 +1980,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         )
 
         q2.addResponse(
+          code = "Q2-R1",
           response = "Q2-R1",
           responseDate = today,
           sequence = 0,
@@ -1970,6 +1990,7 @@ class NomisSyncResourceTest : SqsIntegrationTestBase() {
         )
 
         q3.addResponse(
+          code = "Q3-R1",
           response = "Q3-R1",
           responseDate = today,
           sequence = 0,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -3446,6 +3446,28 @@ class ReportResourceTest : SqsIntegrationTestBase() {
         }
 
         @Test
+        fun `can update existing question with responses that contain codes in response`() {
+          val validUpdateRequest =
+            getResource("/questions-with-responses/update-request-with-responses-with-codes.json")
+          val expectedResponse = getResource("/questions-with-responses/update-response-with-responses-with-codes.json")
+          webTestClient.put().uri(urlWithQuestionsAndResponses)
+            .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCIDENT_REPORTS"), scopes = listOf("write")))
+            .header("Content-Type", "application/json")
+            .bodyValue(validUpdateRequest)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody().json(expectedResponse, JsonCompareMode.STRICT)
+
+          assertThatReportWasModified(existingReportWithQuestionsAndResponses.id!!)
+
+          assertThatDomainEventWasSent(
+            "incident.report.amended",
+            "11124146",
+            whatChanged = WhatChanged.QUESTIONS,
+          )
+        }
+
+        @Test
         fun `can update existing question with responses`() {
           val validUpdateRequest = getResource("/questions-with-responses/update-request-with-responses.json")
           val expectedResponse = getResource("/questions-with-responses/update-response-with-responses.json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
@@ -186,7 +186,7 @@ class NomisSyncServiceTest {
 
   init {
     sampleReport.addQuestion("42", "What implement was used?", 1)
-      .addResponse("Razor", null, 0, null, reportedBy, now)
+      .addResponse("RAZOR", "Razor", null, 0, null, reportedBy, now)
     sampleReport.addStaffInvolved(
       sequence = 0,
       staffRole = StaffRole.PRESENT_AT_SCENE,

--- a/src/test/resources/questions-with-responses/add-and-update-request-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-and-update-request-with-responses.json
@@ -5,10 +5,12 @@
     "additionalInformation": "Updated explanation #1",
     "responses": [
       {
+        "code": "1-1",
         "response": "New response #1",
         "responseDate": "2023-11-30"
       },
       {
+        "code": "1-2",
         "response": "New response #2",
         "additionalInformation": "Comment #1"
       },
@@ -22,6 +24,7 @@
     "question": "Was anybody hurt?",
     "responses": [
       {
+        "code": "2002-1",
         "response": "No"
       }
     ]

--- a/src/test/resources/questions-with-responses/add-and-update-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-and-update-response-with-responses.json
@@ -5,6 +5,7 @@
     "sequence": 1,
     "responses": [
       {
+        "code": "1-1",
         "response": "New response #1",
         "sequence": 0,
         "responseDate": "2023-11-30",
@@ -13,6 +14,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "1-2",
         "response": "New response #2",
         "sequence": 1,
         "responseDate": null,
@@ -21,6 +23,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": null,
         "response": "New response #3",
         "sequence": 2,
         "responseDate": null,
@@ -37,6 +40,7 @@
     "sequence": 2,
     "responses": [
       {
+        "code": "2-1",
         "response": "Response #1",
         "sequence": 0,
         "responseDate": "2023-12-04",
@@ -45,6 +49,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "2-2",
         "response": "Response #2",
         "sequence": 1,
         "responseDate": "2023-12-03",
@@ -62,6 +67,7 @@
     "additionalInformation": null,
     "responses": [
       {
+        "code": "2002-1",
         "response": "No",
         "sequence": 0,
         "responseDate": null,

--- a/src/test/resources/questions-with-responses/add-response-3-questions-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-3-questions-with-responses.json
@@ -5,6 +5,7 @@
     "sequence": 1,
     "responses": [
       {
+        "code": "1-1",
         "response": "Response #1",
         "sequence": 0,
         "responseDate": "2023-12-04",
@@ -13,6 +14,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "1-2",
         "response": "Response #2",
         "sequence": 1,
         "responseDate": "2023-12-03",
@@ -29,6 +31,7 @@
     "sequence": 2,
     "responses": [
       {
+        "code": "2-1",
         "response": "Response #1",
         "sequence": 0,
         "responseDate": "2023-12-04",
@@ -37,6 +40,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "2-2",
         "response": "Response #2",
         "sequence": 1,
         "responseDate": "2023-12-03",
@@ -54,6 +58,7 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
+        "code": null,
         "response": "Note with phone number",
         "sequence": 0,
         "responseDate": null,
@@ -62,6 +67,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": null,
         "response": "Mobile phone",
         "sequence": 1,
         "responseDate": null,
@@ -70,6 +76,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": null,
         "response": "Note with date",
         "sequence": 2,
         "responseDate": "2023-11-30",
@@ -86,6 +93,7 @@
     "additionalInformation": null,
     "responses": [
       {
+        "code": null,
         "response": "No",
         "sequence": 0,
         "responseDate": null,
@@ -102,6 +110,7 @@
     "additionalInformation": null,
     "responses": [
       {
+        "code": null,
         "response": "Yes",
         "sequence": 0,
         "responseDate": "2023-12-01",

--- a/src/test/resources/questions-with-responses/add-response-with-responses-and-null-fields.json
+++ b/src/test/resources/questions-with-responses/add-response-with-responses-and-null-fields.json
@@ -5,6 +5,7 @@
     "sequence": 1,
     "responses": [
       {
+        "code": "1-1",
         "response": "Response #1",
         "sequence": 0,
         "responseDate": "2023-12-04",
@@ -13,6 +14,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "1-2",
         "response": "Response #2",
         "sequence": 1,
         "responseDate": "2023-12-03",
@@ -29,6 +31,7 @@
     "sequence": 2,
     "responses": [
       {
+        "code": "2-1",
         "response": "Response #1",
         "sequence": 0,
         "responseDate": "2023-12-04",
@@ -37,6 +40,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "2-2",
         "response": "Response #2",
         "sequence": 1,
         "responseDate": "2023-12-03",
@@ -54,6 +58,7 @@
     "additionalInformation": null,
     "responses": [
       {
+        "code": null,
         "response": "Note with phone number",
         "sequence": 0,
         "responseDate": null,
@@ -62,6 +67,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": null,
         "response": "Mobile phone",
         "sequence": 1,
         "responseDate": null,
@@ -70,6 +76,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": null,
         "response": "Chewing gum",
         "sequence": 2,
         "responseDate": null,

--- a/src/test/resources/questions-with-responses/add-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-with-responses.json
@@ -5,6 +5,7 @@
     "sequence": 1,
     "responses": [
       {
+        "code": "1-1",
         "response": "Response #1",
         "sequence": 0,
         "responseDate": "2023-12-04",
@@ -13,6 +14,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "1-2",
         "response": "Response #2",
         "sequence": 1,
         "responseDate": "2023-12-03",
@@ -29,6 +31,7 @@
     "sequence": 2,
     "responses": [
       {
+        "code": "2-1",
         "response": "Response #1",
         "sequence": 0,
         "responseDate": "2023-12-04",
@@ -37,6 +40,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "2-2",
         "response": "Response #2",
         "sequence": 1,
         "responseDate": "2023-12-03",
@@ -54,6 +58,7 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
+        "code": null,
         "response": "Note with phone number",
         "sequence": 0,
         "responseDate": null,
@@ -62,6 +67,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": null,
         "response": "Mobile phone",
         "sequence": 1,
         "responseDate": null,
@@ -70,6 +76,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": null,
         "response": "Note with date",
         "sequence": 2,
         "responseDate": "2023-11-30",

--- a/src/test/resources/questions-with-responses/add-response-without-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-without-responses.json
@@ -6,6 +6,7 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
+        "code": null,
         "response": "Note with phone number",
         "sequence": 0,
         "responseDate": null,
@@ -14,6 +15,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": null,
         "response": "Mobile phone",
         "sequence": 1,
         "responseDate": null,
@@ -22,6 +24,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": null,
         "response": "Note with date",
         "sequence": 2,
         "responseDate": "2023-11-30",

--- a/src/test/resources/questions-with-responses/delete-response.json
+++ b/src/test/resources/questions-with-responses/delete-response.json
@@ -5,6 +5,7 @@
     "sequence": 1,
     "responses": [
       {
+        "code": "1-1",
         "response": "Response #1",
         "sequence": 0,
         "responseDate": "2023-12-04",
@@ -13,6 +14,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "1-2",
         "response": "Response #2",
         "sequence": 1,
         "responseDate": "2023-12-03",

--- a/src/test/resources/questions-with-responses/update-request-with-responses-with-codes.json
+++ b/src/test/resources/questions-with-responses/update-request-with-responses-with-codes.json
@@ -1,0 +1,15 @@
+[
+  {
+    "code": "2",
+    "question": "Updated question #2",
+    "additionalInformation": "Updated explanation #2",
+    "responses": [
+      {
+        "code": "NEW-CODE",
+        "response": "New response",
+        "responseDate": null,
+        "additionalInformation": null
+      }
+    ]
+  }
+]

--- a/src/test/resources/questions-with-responses/update-response-with-responses-with-codes.json
+++ b/src/test/resources/questions-with-responses/update-response-with-responses-with-codes.json
@@ -27,28 +27,19 @@
   },
   {
     "code": "2",
-    "question": "Question #2",
+    "question": "Updated question #2",
     "sequence": 2,
     "responses": [
       {
-        "code": "2-1",
-        "response": "Response #1",
+        "code": "NEW-CODE",
+        "response": "New response",
         "sequence": 0,
-        "responseDate": "2023-12-04",
-        "additionalInformation": "Prose #1",
-        "recordedBy": "some-user",
-        "recordedAt": "2023-12-05T12:34:56"
-      },
-      {
-        "code": "2-2",
-        "response": "Response #2",
-        "sequence": 1,
-        "responseDate": "2023-12-03",
-        "additionalInformation": "Prose #2",
-        "recordedBy": "some-user",
+        "responseDate": null,
+        "additionalInformation": null,
+        "recordedBy": "request-user",
         "recordedAt": "2023-12-05T12:34:56"
       }
     ],
-    "additionalInformation": "Explanation #2"
+    "additionalInformation": "Updated explanation #2"
   }
 ]

--- a/src/test/resources/questions-with-responses/update-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/update-response-with-responses.json
@@ -5,6 +5,7 @@
     "sequence": 1,
     "responses": [
       {
+        "code": "1-1",
         "response": "Response #1",
         "sequence": 0,
         "responseDate": "2023-12-04",
@@ -13,6 +14,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
+        "code": "1-2",
         "response": "Response #2",
         "sequence": 1,
         "responseDate": "2023-12-03",
@@ -29,6 +31,7 @@
     "sequence": 2,
     "responses": [
       {
+        "code": null,
         "response": "New response",
         "sequence": 0,
         "responseDate": null,


### PR DESCRIPTION
This Pull Request introduces a new code field to various response-related models, both in the API layer (DTOs) and the database schema. The code field serves as a unique identifier for responses, enabling better traceability and uniqueness. Changes are also accompanied by updates to tests, JSON payloads, and database migrations.
### Main Changes:
- New Field Addition:
  - Added code as an optional field in the HistoricalResponse, Response, and related models.
  - Updated constructors and methods across models to incorporate the new code field.
- Database Updates:
  - Added a new code column to the response and historical_response tables via SQL migration.
  - Indexed the code column for performance when used with question_id.
- Logic Updates:
  - Modified methods to handle the new code field for inserting/updating responses in entities like Question and HistoricalQuestion.
- Test Updates:
  - Updated various test files (e.g., requests, responses, and integration tests) to include the code field in the test data for better validation.
  - Added checks for backward compatibility by leaving the code field nullable until migration completion.