### PR TITLE
IR-1115 Make `code` field mandatory for responses. (#367)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddOrUpdateQuestionWithResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/AddOrUpdateQuestionWithResponses.kt
@@ -41,7 +41,6 @@ data class AddOrUpdateQuestionWithResponses(
 
 @Schema(description = "A response to a question", accessMode = Schema.AccessMode.WRITE_ONLY)
 data class AddOrUpdateQuestionResponse(
-  // TODO: WARNING will overwrite any existing response code if null.  This will change once we have the code as mandatory
   @Schema(
     description = "The response code; used as a unique identifier within one report",
     requiredMode = Schema.RequiredMode.NOT_REQUIRED,
@@ -49,7 +48,7 @@ data class AddOrUpdateQuestionResponse(
     maxLength = 60,
   )
   @field:Size(min = 1, max = 60)
-  val code: String? = null,
+  val code: String,
   @Schema(
     description = "The response text as seen by downstream data consumers",
     requiredMode = Schema.RequiredMode.REQUIRED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalQuestion.kt
@@ -120,7 +120,7 @@ class HistoricalQuestion(
   }
 
   fun addResponse(
-    code: String?,
+    code: String,
     response: String,
     sequence: Int,
     responseDate: LocalDate? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/HistoricalResponse.kt
@@ -22,8 +22,7 @@ class HistoricalResponse(
   @ManyToOne(fetch = FetchType.LAZY)
   val historicalQuestion: HistoricalQuestion,
 
-  // TODO: remove nullable once migrated.
-  val code: String?,
+  val code: String,
 
   val sequence: Int,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Question.kt
@@ -127,7 +127,7 @@ class Question(
   }
 
   fun addResponse(
-    code: String?,
+    code: String,
     response: String,
     responseDate: LocalDate? = null,
     sequence: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Response.kt
@@ -24,9 +24,8 @@ class Response(
 
   /**
    * Identifier that refers to a specific answer for an incident type.
-   * TODO: remove nullable once migrated.
    */
-  val code: String?,
+  val code: String,
 
   val sequence: Int,
 

--- a/src/main/resources/db/migration/V1_25__make_response_code_not_null.sql
+++ b/src/main/resources/db/migration/V1_25__make_response_code_not_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE response ALTER COLUMN code SET NOT NULL;
+ALTER TABLE historical_response ALTER COLUMN code SET NOT NULL;

--- a/src/test/resources/questions-with-responses/add-and-update-request-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-and-update-request-with-responses.json
@@ -15,6 +15,7 @@
         "additionalInformation": "Comment #1"
       },
       {
+        "code": "1-3",
         "response": "New response #3"
       }
     ]

--- a/src/test/resources/questions-with-responses/add-and-update-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-and-update-response-with-responses.json
@@ -23,7 +23,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
-        "code": null,
+        "code": "1-3",
         "response": "New response #3",
         "sequence": 2,
         "responseDate": null,

--- a/src/test/resources/questions-with-responses/add-request-3-questions-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-request-3-questions-with-responses.json
@@ -5,14 +5,17 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
+        "code": "2001-1",
         "response": "Note with phone number",
         "additionalInformation": "020 1111 2222"
       },
       {
+        "code": "2001-2",
         "response": "Mobile phone",
         "additionalInformation": "Not a smartphone"
       },
       {
+        "code": "2001-3",
         "response": "Note with date",
         "responseDate": "2023-11-30"
       }
@@ -23,6 +26,7 @@
     "question": "Was anybody hurt?",
     "responses": [
       {
+        "code": "2002-1",
         "response": "No"
       }
     ]
@@ -32,6 +36,7 @@
     "question": "Was the governor informed?",
     "responses": [
       {
+        "code": "2003-1",
         "response": "Yes",
         "responseDate": "2023-12-01"
       }

--- a/src/test/resources/questions-with-responses/add-request-empty-question.json
+++ b/src/test/resources/questions-with-responses/add-request-empty-question.json
@@ -5,10 +5,12 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
+        "code": "2001-1",
         "response": "Note with phone number",
         "additionalInformation": "020 1111 2222"
       },
       {
+        "code": "2001-2",
         "response": "Mobile phone",
         "responseDate": "2023-12-04",
         "additionalInformation": "Not a smartphone"

--- a/src/test/resources/questions-with-responses/add-request-empty-response.json
+++ b/src/test/resources/questions-with-responses/add-request-empty-response.json
@@ -5,11 +5,13 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
+        "code": "2001-1",
         "response": "Note with phone number",
         "responseDate": "2023-12-04",
         "additionalInformation": "020 1111 2222"
       },
       {
+        "code": "2001-2",
         "response": "",
         "additionalInformation": "Mobile phone"
       }

--- a/src/test/resources/questions-with-responses/add-request-long-code.json
+++ b/src/test/resources/questions-with-responses/add-request-long-code.json
@@ -5,10 +5,12 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
+        "code": "2001-1",
         "response": "Note with phone number",
         "additionalInformation": "020 1111 2222"
       },
       {
+        "code": "2001-2",
         "response": "Mobile phone",
         "additionalInformation": "Not a smartphone"
       }

--- a/src/test/resources/questions-with-responses/add-request-with-responses-and-null-fields.json
+++ b/src/test/resources/questions-with-responses/add-request-with-responses-and-null-fields.json
@@ -5,13 +5,16 @@
     "additionalInformation": null,
     "responses": [
       {
+        "code": "2001-1",
         "response": "Note with phone number"
       },
       {
+        "code": "2001-2",
         "response": "Mobile phone",
         "additionalInformation": null
       },
       {
+        "code": "2001-3",
         "response": "Chewing gum",
         "responseDate": null
       }

--- a/src/test/resources/questions-with-responses/add-request-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-request-with-responses.json
@@ -5,14 +5,17 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
+        "code": "2001-1",
         "response": "Note with phone number",
         "additionalInformation": "020 1111 2222"
       },
       {
+        "code": "2001-2",
         "response": "Mobile phone",
         "additionalInformation": "Not a smartphone"
       },
       {
+        "code": "2001-3",
         "response": "Note with date",
         "responseDate": "2023-11-30"
       }

--- a/src/test/resources/questions-with-responses/add-response-3-questions-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-3-questions-with-responses.json
@@ -58,7 +58,7 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
-        "code": null,
+        "code": "2001-1",
         "response": "Note with phone number",
         "sequence": 0,
         "responseDate": null,
@@ -67,7 +67,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
-        "code": null,
+        "code": "2001-2",
         "response": "Mobile phone",
         "sequence": 1,
         "responseDate": null,
@@ -76,7 +76,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
-        "code": null,
+        "code": "2001-3",
         "response": "Note with date",
         "sequence": 2,
         "responseDate": "2023-11-30",
@@ -93,7 +93,7 @@
     "additionalInformation": null,
     "responses": [
       {
-        "code": null,
+        "code": "2002-1",
         "response": "No",
         "sequence": 0,
         "responseDate": null,
@@ -110,7 +110,7 @@
     "additionalInformation": null,
     "responses": [
       {
-        "code": null,
+        "code": "2003-1",
         "response": "Yes",
         "sequence": 0,
         "responseDate": "2023-12-01",

--- a/src/test/resources/questions-with-responses/add-response-with-responses-and-null-fields.json
+++ b/src/test/resources/questions-with-responses/add-response-with-responses-and-null-fields.json
@@ -58,7 +58,7 @@
     "additionalInformation": null,
     "responses": [
       {
-        "code": null,
+        "code": "2001-1",
         "response": "Note with phone number",
         "sequence": 0,
         "responseDate": null,
@@ -67,7 +67,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
-        "code": null,
+        "code": "2001-2",
         "response": "Mobile phone",
         "sequence": 1,
         "responseDate": null,
@@ -76,7 +76,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
-        "code": null,
+        "code": "2001-3",
         "response": "Chewing gum",
         "sequence": 2,
         "responseDate": null,

--- a/src/test/resources/questions-with-responses/add-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-with-responses.json
@@ -58,7 +58,7 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
-        "code": null,
+        "code": "2001-1",
         "response": "Note with phone number",
         "sequence": 0,
         "responseDate": null,
@@ -67,7 +67,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
-        "code": null,
+        "code": "2001-2",
         "response": "Mobile phone",
         "sequence": 1,
         "responseDate": null,
@@ -76,7 +76,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
-        "code": null,
+        "code": "2001-3",
         "response": "Note with date",
         "sequence": 2,
         "responseDate": "2023-11-30",

--- a/src/test/resources/questions-with-responses/add-response-without-responses.json
+++ b/src/test/resources/questions-with-responses/add-response-without-responses.json
@@ -6,7 +6,7 @@
     "additionalInformation": "Amounts do not matter",
     "responses": [
       {
-        "code": null,
+        "code": "2001-1",
         "response": "Note with phone number",
         "sequence": 0,
         "responseDate": null,
@@ -15,7 +15,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
-        "code": null,
+        "code": "2001-2",
         "response": "Mobile phone",
         "sequence": 1,
         "responseDate": null,
@@ -24,7 +24,7 @@
         "recordedAt": "2023-12-05T12:34:56"
       },
       {
-        "code": null,
+        "code": "2001-3",
         "response": "Note with date",
         "sequence": 2,
         "responseDate": "2023-11-30",

--- a/src/test/resources/questions-with-responses/update-request-with-responses.json
+++ b/src/test/resources/questions-with-responses/update-request-with-responses.json
@@ -5,6 +5,7 @@
     "additionalInformation": "Updated explanation #2",
     "responses": [
       {
+        "code": "2-2",
         "response": "New response",
         "responseDate": null,
         "additionalInformation": null

--- a/src/test/resources/questions-with-responses/update-response-with-responses.json
+++ b/src/test/resources/questions-with-responses/update-response-with-responses.json
@@ -31,7 +31,7 @@
     "sequence": 2,
     "responses": [
       {
-        "code": null,
+        "code": "2-2",
         "response": "New response",
         "sequence": 0,
         "responseDate": null,


### PR DESCRIPTION
- Made the code field non-null in multiple data classes (AddOrUpdateQuestionResponse, HistoricalQuestion, HistoricalResponse, Question, and Response) to enforce mandatory values.
- Updated related methods (addResponse) to align with the non-null constraint for code.
- Added a database migration script to set the code field as NOT NULL in the response and historical_response tables.
- Updated test data JSON files to include non-null code fields where applicable.