### PR TITLE
Tweaked start/stop and retry-dlq schedules

### DIFF
--- a/helm_deploy/hmpps-incident-reporting-api/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting-api/values.yaml
@@ -14,6 +14,10 @@ generic-service:
     tag: app_version # override at deployment time
     port: 8080
 
+  scheduledDowntime:
+    startup: '49 6 * * 1-5' # Start at 6.49am UTC Monday-Friday
+    shutdown: '58 21 * * 1-5' # Stop at 9.58pm UTC Monday-Friday
+
   retryDlqCronjob:
     enabled: true
 
@@ -66,9 +70,6 @@ generic-service:
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform
-
-  scheduledDowntime:
-    timeZone: Europe/London
 
   modsecurity_enabled: true
   modsecurity_snippet: |

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,8 +6,6 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
-    startup: '49 6 * * 1-5' # Start at 6.49am Monday-Friday
-    shutdown: '58 21 * * 1-5' # Stop at 9.58pm Monday-Friday
 
   ingress:
     host: incident-reporting-api-dev.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -6,8 +6,6 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
-    startup: '49 6 * * 1-5' # Start at 6.49am Monday-Friday
-    shutdown: '58 21 * * 1-5' # Stop at 9.58pm Monday-Friday
 
   ingress:
     host: incident-reporting-api-preprod.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,6 +5,9 @@ generic-service:
   ingress:
     host: incident-reporting-api.hmpps.service.justice.gov.uk
 
+  scheduledDowntime:
+    enabled: false
+
   resources:
     requests:
       memory: 4G


### PR DESCRIPTION
- Use UTC consistenly to avoid confusion and differences that can cause issues, especially in the summer (when BST is in effect)
- API starts at 6:49am UTC now
- retry-dlq CronJob first run will be at 7:00am UTC
- API stops at 21:59pm UTC now
- retry-dlq CronJob last run will be at 9:50pm UTC

In addition (in a separate PR), UI will also:
- start at 7:00am UTC
- stop at 9:50pm UTC

**NOTE**: Ideally this should be applied around the same time as [this sibling UI PR](https://github.com/ministryofjustice/hmpps-incident-reporting/pull/484).