### PR TITLE
Increased memory across all the environments

### DIFF
--- a/helm_deploy/hmpps-incident-reporting-api/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting-api/values.yaml
@@ -37,7 +37,7 @@ generic-service:
           return 401;
         }
   env:
-    JAVA_OPTS: "-Xmx768m"
+    JAVA_OPTS: "-Xmx3g"
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json


### PR DESCRIPTION
Since yesterday afternoon we're seeing a lot of errors in `dev` and pods restarts.

Pods logs have a bunch of errors like:
`java.lang.OutOfMemoryError: Java heap space`

While the RDS instance resource usage seems to be fine, but the logs also have a bunch of errors along the line of `connection reset by peer`, again, pointing in the direction of the API pods rather than a problem with the DB sizing (AFAICT).

Production memory was already [tweaked in March] possibly because of a similar problem, so I'm updating the
memory across all the environments, specifically the Java maximum heap memory allocation.

[tweaked in March]: https://github.com/ministryofjustice/hmpps-incident-reporting-api/commit/d059c3e8126d38661e1c21d241142b1750f54673