### PR TITLE
Increase k8s pod memory limit

### DIFF
--- a/helm_deploy/hmpps-incident-reporting-api/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting-api/values.yaml
@@ -9,6 +9,10 @@ generic-service:
 
   replicaCount: 4
 
+  resources:
+    limits:
+      memory: 3.5G
+
   image:
     repository: ghcr.io/ministryofjustice/hmpps-incident-reporting-api
     tag: app_version # override at deployment time


### PR DESCRIPTION
We have increased the Java max memory heap allocation but the k8s pods seem to have a memory limit of
1GB even tho we haven't set that anywhere:

```YAML
    resources:
      limits:
        cpu: "2"
        memory: 1Gi
      requests:
        cpu: 10m
        memory: 512Mi
```

This would be hit by the application before the
3GB Java limit, so I'm bumping this to match that.