### PR TITLE
IR-1040: Remove “Post-incident update” status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
@@ -22,9 +22,6 @@ enum class Status(
   UPDATED("Updated", "INAME"),
   CLOSED("Closed", "CLOSE"),
 
-  // TODO: POST_INCIDENT_UPDATE will be removed
-  POST_INCIDENT_UPDATE("Post-incident update", "PIU"),
-
   DUPLICATE("Duplicate", "DUP"),
   NOT_REPORTABLE("Not reportable", null),
   REOPENED("Reopened", null),

--- a/src/main/resources/db/migration/V1_31__delete_post_incident_update_status.sql
+++ b/src/main/resources/db/migration/V1_31__delete_post_incident_update_status.sql
@@ -1,0 +1,5 @@
+-- Removes POST_INCIDENT_UPDATE status which has now been removed from NOMIS
+-- See: https://dsdmoj.atlassian.net/wiki/spaces/IR/pages/5589893167/Status+old+and+new
+
+DELETE FROM constant_status
+WHERE code = 'POST_INCIDENT_UPDATE';


### PR DESCRIPTION
…it’s now gone from NOMIS in all environments