### PR TITLE
IR-1160 Introduce OAuth2 client configuration and caching service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/ClientCachingOAuth2AuthorizedClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/ClientCachingOAuth2AuthorizedClientService.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.config
+
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientId
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import uk.gov.justice.digital.hmpps.incidentreporting.SYSTEM_USERNAME
+import java.util.concurrent.ConcurrentHashMap
+
+class ClientCachingOAuth2AuthorizedClientService(
+  private val clientRegistrationRepository: ClientRegistrationRepository,
+) : OAuth2AuthorizedClientService {
+  private val authorizedClients: MutableMap<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> = ConcurrentHashMap()
+
+  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
+    clientRegistrationId: String,
+    principalName: String,
+  ): T? = clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.let {
+    @Suppress("UNCHECKED_CAST")
+    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME)] as T
+  }
+
+  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {
+    authorizedClients[
+      OAuth2AuthorizedClientId(authorizedClient.clientRegistration.registrationId, SYSTEM_USERNAME),
+    ] = authorizedClient
+  }
+
+  override fun removeAuthorizedClient(clientRegistrationId: String, principalName: String) {
+    clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.apply {
+      authorizedClients.remove(OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME))
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/OAuth2ClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/config/OAuth2ClientConfiguration.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.incidentreporting.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+
+@Configuration
+class OAuth2ClientConfiguration {
+
+  @Bean
+  fun authorizedClientManager(
+    clientRegistrationRepository: ClientRegistrationRepository,
+  ): OAuth2AuthorizedClientManager {
+    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
+    val authorizedClientManager =
+      AuthorizedClientServiceOAuth2AuthorizedClientManager(
+        clientRegistrationRepository,
+        ClientCachingOAuth2AuthorizedClientService(clientRegistrationRepository),
+      )
+    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
+    return authorizedClientManager
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/integration/wiremock/HmppsAuthMockServer.kt
@@ -21,7 +21,8 @@ class HmppsAuthMockServer : MockServer(HMPPS_AUTH_WIREMOCK_PORT, "/auth") {
               """
               {
                 "token_type": "bearer",
-                "access_token": "ABCDE"
+                "access_token": "ABCDE",
+                "expires_in": 3600
               }
               """,
             ),


### PR DESCRIPTION
- **Summary of Changes**:  
  Added support for OAuth2 client configuration, including a new `OAuth2ClientConfiguration` class for enhanced client manager setup. Also implemented an in-memory caching service, `ClientCachingOAuth2AuthorizedClientService`, to efficiently store authorized clients. Updated `HmppsAuthMockServer` to return token expiration details.  

- **Related Issues**:  
  (No related issues were provided for this Pull Request.)  

- **Testing**:  
  Tested the new client configurations and caching services with mock OAuth2 responses to ensure compatibility and correct behavior.  