### PR TITLE
Undo IR-1040: Remove “Post-incident update” status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
@@ -22,6 +22,9 @@ enum class Status(
   UPDATED("Updated", "INAME"),
   CLOSED("Closed", "CLOSE"),
 
+  // TODO: POST_INCIDENT_UPDATE will be removed
+  POST_INCIDENT_UPDATE("Post-incident update", "PIU"),
+
   DUPLICATE("Duplicate", "DUP"),
   NOT_REPORTABLE("Not reportable", null),
   REOPENED("Reopened", null),

--- a/src/main/resources/db/migration/V1_32__undelete_post_incident_update_status.sql
+++ b/src/main/resources/db/migration/V1_32__undelete_post_incident_update_status.sql
@@ -1,0 +1,5 @@
+-- Re-add POST_INCIDENT_UPDATE status because it was not fully removed from NOMIS
+-- See: https://dsdmoj.atlassian.net/wiki/spaces/IR/pages/5589893167/Status+old+and+new
+
+insert into constant_status(sequence, code, description)
+values (6, 'POST_INCIDENT_UPDATE', 'Post-incident update');


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-incident-reporting-api#376