### PR TITLE
IR-1040: Re-remove “Post-incident update” status

### DIFF
--- a/docs/0004-modeling-irs.md
+++ b/docs/0004-modeling-irs.md
@@ -83,6 +83,7 @@ classDiagram
     UUID id
     LocalDateTime createdAt
     String description
+    UUID duplicatedReportId
     LocalDateTime incidentDateAndTime
     String location
     LocalDateTime modifiedAt
@@ -126,16 +127,16 @@ classDiagram
     Status status
   }
 
-  CorrectionRequest "0..*" <--> "1" Report
   HistoricalQuestion "1" <--> "1..*" HistoricalResponse
   HistoricalQuestion "0..*" <--> "1" History
-  PrisonerInvolvement "0..*" <--> "1" Report
   Question "0..*" <--> "1" Report
   Question "1" <--> "1..*" Response
+  Report "1" <--> "0..*" CorrectionRequest
   Report "1" <--> "0..*" DescriptionAddendum
   Report "1" <--> "0..*" History
+  Report "1" <--> "0..*" PrisonerInvolvement
   Report "1" <--> "0..*" StaffInvolvement
-  StatusHistory "1..*" <--> "1" Report
+  Report "1" <--> "1..*" StatusHistory
 ```
 
 ### DB Schema
@@ -273,6 +274,7 @@ classDiagram
     varchar(5) modified_in
     boolean staff_involvement_done
     boolean prisoner_involvement_done
+    uuid duplicated_report_id
     uuid id
   }
   class response {
@@ -312,6 +314,7 @@ classDiagram
   history --> report: report_id
   prisoner_involvement --> report: report_id
   question --> report: report_id
+  report --> report: duplicated_report_id
   response --> question: question_id
   staff_involvement --> report: report_id
   status_history --> report: report_id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
@@ -22,9 +22,6 @@ enum class Status(
   UPDATED("Updated", "INAME"),
   CLOSED("Closed", "CLOSE"),
 
-  // TODO: POST_INCIDENT_UPDATE will be removed
-  POST_INCIDENT_UPDATE("Post-incident update", "PIU"),
-
   DUPLICATE("Duplicate", "DUP"),
   NOT_REPORTABLE("Not reportable", null),
   REOPENED("Reopened", null),

--- a/src/main/resources/db/migration/V1_33__correctly_delete_post_incident_update_status.sql
+++ b/src/main/resources/db/migration/V1_33__correctly_delete_post_incident_update_status.sql
@@ -1,0 +1,15 @@
+-- Re-removes POST_INCIDENT_UPDATE status which had in fact been deactivated in NOMIS correctly,
+-- but foolishly NOT removed from `status_history` in migration 1.31
+-- See: https://dsdmoj.atlassian.net/wiki/spaces/IR/pages/5589893167/Status+old+and+new
+
+update report
+set status='ON_HOLD'
+where status = 'POST_INCIDENT_UPDATE';
+
+update status_history
+set status='ON_HOLD'
+where status = 'POST_INCIDENT_UPDATE';
+
+delete
+from constant_status
+where code = 'POST_INCIDENT_UPDATE';


### PR DESCRIPTION
`PIU` had in fact been deactivated in NOMIS correctly, but remained in the status history table here – such reports could no longer be deserialised from the database correctly.