### PR TITLE
Fix `matchPackageNames` matches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,14 +6,14 @@
   "packageRules": [
     {
       "matchManagers": ["gradle"],
-      "matchPackageNames": ["swagger-parser"],
+      "matchPackageNames": ["io.swagger.parser.v3:swagger-parser"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "swagger-parser",
       "groupSlug": "swagger-parser"
     },
     {
       "matchManagers": ["gradle"],
-      "matchPackageNames": ["hmpps-digital-prison-reporting-lib"],
+      "matchPackageNames": ["uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "hmpps-digital-prison-reporting-lib",
       "groupSlug": "hmpps-digital-prison-reporting-lib"


### PR DESCRIPTION
Renovate considers the whole path of package as
package name, e.g. for a package called `org.springframework.boot:spring-boot-starter-web` `matchPackageNames` would have to be the whole `group:name`, so

```
"matchPackageNames": ["org.springframework.boot:spring-boot-starter-web"]
```

Or use regular expressions.