### PR TITLE
Attempt to fix renovate rules order

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,12 @@
   "packageRules": [
     {
       "matchManagers": ["gradle"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non major Gradle dependencies",
+      "groupSlug": "all-gradle-minor-patch"
+    },
+    {
+      "matchManagers": ["gradle"],
       "matchPackageNames": ["io.swagger.parser.v3:swagger-parser"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "swagger-parser",
@@ -17,12 +23,6 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "hmpps-digital-prison-reporting-lib",
       "groupSlug": "hmpps-digital-prison-reporting-lib"
-    },
-    {
-      "matchManagers": ["gradle"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "all non major Gradle dependencies",
-      "groupSlug": "all-gradle-minor-patch"
     }
   ]
 }


### PR DESCRIPTION
Renovates applies the first matching `packageRule` or so I thought, but apparently when more than one rule matches the last rule wins - so it's the opposite of what I thought: More specific rules should come after.