### PR TITLE
Add `ignore_downstream` flag to status constants table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
@@ -14,6 +14,7 @@ import jakarta.validation.ValidationException
 enum class Status(
   val description: String,
   val nomisStatus: String?,
+  val ignoreDownstream: Boolean = false,
 ) {
   DRAFT("Draft", null),
   AWAITING_REVIEW("Awaiting review", "AWAN"),
@@ -22,10 +23,11 @@ enum class Status(
   UPDATED("Updated", "INAME"),
   CLOSED("Closed", "CLOSE"),
 
-  DUPLICATE("Duplicate", "DUP"),
-  NOT_REPORTABLE("Not reportable", null),
-  REOPENED("Reopened", null),
-  WAS_CLOSED("Was closed", null),
+  // following statuses should be ignored downstream for most statistical purposes
+  DUPLICATE("Duplicate", "DUP", true),
+  NOT_REPORTABLE("Not reportable", null, true),
+  REOPENED("Reopened", null, true),
+  WAS_CLOSED("Was closed", null, true),
   ;
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/StatusConstantDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/StatusConstantDescription.kt
@@ -10,6 +10,11 @@ data class StatusConstantDescription(
   val code: String,
   @param:Schema(description = "Human-readable description of this value", example = "On hold")
   val description: String,
+  @param:Schema(
+    description = "Whether reports with this status should be ignored downstream for most statistical purposes",
+    example = "false",
+  )
+  val ignoreDownstream: Boolean,
 
   // NB: this property can be removed once fully migrated off NOMIS and reconciliation checks are turned off
   @param:Schema(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResource.kt
@@ -132,7 +132,7 @@ class ConstantsResource {
   )
   fun statuses(): List<StatusConstantDescription> {
     return Status.entries.map {
-      StatusConstantDescription(it.name, it.description, it.nomisStatus)
+      StatusConstantDescription(it.name, it.description, it.ignoreDownstream, it.nomisStatus)
     }
   }
 

--- a/src/main/resources/db/migration/V1_34__statuses_ignored_downstream.sql
+++ b/src/main/resources/db/migration/V1_34__statuses_ignored_downstream.sql
@@ -1,0 +1,6 @@
+alter table constant_status
+  add column ignore_downstream boolean not null default false;
+
+update constant_status
+set ignore_downstream = true
+where code in ('DUPLICATE', 'NOT_REPORTABLE', 'REOPENED', 'WAS_CLOSED');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
@@ -122,11 +122,13 @@ class ConstantsResourceTest : SqsIntegrationTestBase() {
           "code" to "DRAFT",
           "description" to "Draft",
           "nomisCode" to null,
+          "ignoreDownstream" to false,
         ),
         mapOf(
           "code" to "ON_HOLD",
           "description" to "On hold",
           "nomisCode" to "INAN",
+          "ignoreDownstream" to false,
         ),
       ),
     ),


### PR DESCRIPTION
…so that other services can know which report statuses should be ignored for most statistical purposes