### PR TITLE
IR-1171 Dump out Heap space

### DIFF
--- a/helm_deploy/hmpps-incident-reporting-api/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting-api/values.yaml
@@ -43,7 +43,8 @@ generic-service:
           return 401;
         }
   env:
-    JAVA_OPTS: "-Xmx4g"
+    JAVA_OPTS: "-Xmx4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError"
+
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json

--- a/helm_deploy/hmpps-incident-reporting-api/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting-api/values.yaml
@@ -43,7 +43,7 @@ generic-service:
           return 401;
         }
   env:
-    JAVA_OPTS: "-Xmx4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError"
+    JAVA_OPTS: "-Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError"
 
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,7 +19,7 @@ generic-service:
       memory: 4G
 
   env:
-    JAVA_OPTS: "-Xmx2g -Xmx3g -XX:+HeapDumpOnOutOfMemoryError"
+    JAVA_OPTS: "-Xms2g -Xmx3g -XX:+HeapDumpOnOutOfMemoryError"
     SPRING_PROFILES_ACTIVE: "logstash, replica"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,7 +19,7 @@ generic-service:
       memory: 4G
 
   env:
-    JAVA_OPTS: "-Xmx3g"
+    JAVA_OPTS: "-Xmx2g -Xmx3g -XX:+HeapDumpOnOutOfMemoryError"
     SPRING_PROFILES_ACTIVE: "logstash, replica"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,7 +16,7 @@ generic-service:
     limits:
       memory: 4G
   env:
-    JAVA_OPTS: "-Xmx2g -Xmx3g -XX:+HeapDumpOnOutOfMemoryError"
+    JAVA_OPTS: "-Xms2g -Xmx3g -XX:+HeapDumpOnOutOfMemoryError"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search-preprod.prison.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,7 +16,7 @@ generic-service:
     limits:
       memory: 4G
   env:
-    JAVA_OPTS: "-Xmx3g"
+    JAVA_OPTS: "-Xmx2g -Xmx3g -XX:+HeapDumpOnOutOfMemoryError"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search-preprod.prison.service.justice.gov.uk

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/PrisonOffenderEventListener.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.incidentreporting.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.awspring.cloud.sqs.annotation.SqsListener
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -25,11 +23,11 @@ class PrisonOffenderEventListener(
   }
 
   @SqsListener("incidentreporting", factory = "hmppsQueueContainerFactoryProxy")
-  @WithSpan(value = "hmpps-incident-reporting-prisoner-event-queue", kind = SpanKind.SERVER)
   fun onPrisonOffenderEvent(requestJson: String) {
+    log.info("Received message [$requestJson]")
     val (message, messageAttributes) = mapper.readValue(requestJson, HMPPSMessage::class.java)
     val eventType = messageAttributes.eventType.Value
-    log.info("Received message $message, type $eventType")
+    log.info("Processing message $message, type $eventType")
 
     when (eventType) {
       PRISONER_MERGE_EVENT_TYPE -> {


### PR DESCRIPTION
This Pull Request updates the configuration files for various environments and modifies the PrisonOffenderEventListener class by removing unnecessary imports and improving log messages.
## Main Changes
### Configuration Updates:
Added -XX:+HeapDumpOnOutOfMemoryError option to JAVA_OPTS across multiple environment-specific YAML files.
Adjusted memory limits in some environments.
### Code Changes:
Removed OpenTelemetry-related imports (SpanKind and WithSpan) from PrisonOffenderEventListener.
Improved log message structure for message reception and processing in PrisonOffenderEventListener.