### PR TITLE
IR-1171 Remove memory-intensive eager fetching and standardize configurations

### DIFF
--- a/helm_deploy/hmpps-incident-reporting-api/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting-api/values.yaml
@@ -43,8 +43,7 @@ generic-service:
           return 401;
         }
   env:
-    JAVA_OPTS: "-Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError"
-
+    JAVA_OPTS: "-Xmx3g"
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,14 +12,7 @@ generic-service:
 
   allowlist: null
 
-  resources:
-    requests:
-      memory: 3G
-    limits:
-      memory: 4G
-
   env:
-    JAVA_OPTS: "-Xms2g -Xmx3g -XX:+HeapDumpOnOutOfMemoryError"
     SPRING_PROFILES_ACTIVE: "logstash, replica"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,13 +10,7 @@ generic-service:
   ingress:
     host: incident-reporting-api-preprod.hmpps.service.justice.gov.uk
 
-  resources:
-    requests:
-      memory: 3G
-    limits:
-      memory: 4G
   env:
-    JAVA_OPTS: "-Xms2g -Xmx3g -XX:+HeapDumpOnOutOfMemoryError"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search-preprod.prison.service.justice.gov.uk

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -51,7 +51,6 @@ import uk.gov.justice.digital.hmpps.incidentreporting.dto.DescriptionAddendum as
         NamedAttributeNode("staffInvolved"),
         NamedAttributeNode("prisonersInvolved"),
         NamedAttributeNode("correctionRequests"),
-        NamedAttributeNode("historyOfStatuses"),
         NamedAttributeNode("questions", subgraph = "questions.eager.subgraph"),
         NamedAttributeNode("history", subgraph = "history.eager.subgraph"),
       ],


### PR DESCRIPTION
### Summary of Changes
- Removed `historyOfStatuses` attribute from eager fetching in the `Report` subgraph to address Cartesian join memory issues.
- Cleaned up memory-related configurations for better consistency.
- Standardized `JAVA_OPTS` across all Helm values files.