### PR TITLE
IR-1214 Add `latestUserAction` field to `Report` and associated DTOs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportBasic.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportBasic.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Status
 import uk.gov.justice.digital.hmpps.incidentreporting.constants.Type
+import uk.gov.justice.digital.hmpps.incidentreporting.constants.UserAction
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -51,4 +52,6 @@ open class ReportBasic(
     nullable = true,
   )
   val duplicatedReportId: UUID? = null,
+  @param:Schema(description = "Latest user action from the most recent correction request", nullable = true)
+  val latestUserAction: UserAction? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/ReportWithDetails.kt
@@ -31,6 +31,7 @@ class ReportWithDetails(
   createdInNomis: Boolean,
   lastModifiedInNomis: Boolean,
   duplicatedReportId: UUID?,
+  latestUserAction: UserAction?,
 
   @param:Schema(description = "The question-response pairs that make up this report")
   val questions: List<Question>,
@@ -57,9 +58,6 @@ class ReportWithDetails(
       "if false, is used to indicate that addition of prisoner involvements is unfinished",
   )
   val prisonerInvolvementDone: Boolean,
-
-  @param:Schema(description = "Latest user action from the most recent correction request", nullable = true)
-  val latestUserAction: UserAction?,
 ) : ReportBasic(
   id = id,
   reportReference = reportReference,
@@ -77,6 +75,7 @@ class ReportWithDetails(
   createdInNomis = createdInNomis,
   lastModifiedInNomis = lastModifiedInNomis,
   duplicatedReportId = duplicatedReportId,
+  latestUserAction = latestUserAction,
 ) {
   // NB: this property can be removed once fully migrated off NOMIS and reconciliation checks are turned off
   @Suppress("unused")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/Report.kt
@@ -672,6 +672,7 @@ class Report(
     createdInNomis = source == InformationSource.NOMIS,
     lastModifiedInNomis = modifiedIn == InformationSource.NOMIS,
     duplicatedReportId = duplicatedReportId,
+    latestUserAction = lastUserAction,
   )
 
   fun toDtoWithDetails(includeHistory: Boolean = false) = ReportWithDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/helper/ReportBuilder.kt
@@ -23,6 +23,7 @@ fun buildReport(
   type: Type = Type.FIND_6,
   reportingUsername: String = "USER1",
   duplicatedReportId: UUID? = null,
+  lastUserAction: UserAction? = null,
   // all "related objects" are optionally generated:
   generateDescriptionAddendums: Int = 0,
   generateStaffInvolvement: Int = 0,
@@ -49,6 +50,7 @@ fun buildReport(
     reportedBy = reportingUsername,
     modifiedBy = reportingUsername,
     duplicatedReportId = duplicatedReportId,
+    lastUserAction = lastUserAction,
   )
   report.addStatusHistory(report.status, reportTime, reportingUsername)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ReportResourceTest.kt
@@ -71,6 +71,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
       buildReport(
         reportReference = "11124143",
         reportTime = now,
+        lastUserAction = UserAction.REQUEST_NOT_REPORTABLE,
       ),
     )
   }
@@ -497,7 +498,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "modifiedBy": "USER1",
               "createdInNomis": false,
               "lastModifiedInNomis": false,
-              "duplicatedReportId": null
+              "duplicatedReportId": null,
+              "latestUserAction": "REQUEST_NOT_REPORTABLE"
             }
             """,
             JsonCompareMode.STRICT,
@@ -577,7 +579,7 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "staffInvolved": [],
               "prisonersInvolved": [],
               "correctionRequests": [],
-              "latestUserAction": null,
+              "latestUserAction": "REQUEST_NOT_REPORTABLE",
               "staffInvolvementDone": true,
               "prisonerInvolvementDone": true,
               "reportedBy": "USER1",
@@ -661,7 +663,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "modifiedBy": "USER1",
               "createdInNomis": false,
               "lastModifiedInNomis": false,
-              "duplicatedReportId": null
+              "duplicatedReportId": null,
+              "latestUserAction": "REQUEST_NOT_REPORTABLE"
             }
             """,
             JsonCompareMode.STRICT,
@@ -753,7 +756,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "modifiedBy": "USER1",
               "createdInNomis": false,
               "lastModifiedInNomis": false,
-              "duplicatedReportId": null
+              "duplicatedReportId": null,
+              "latestUserAction": "REQUEST_NOT_REPORTABLE"
             }
             """,
             JsonCompareMode.STRICT,
@@ -1052,7 +1056,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "modifiedBy": "USER1",
               "createdInNomis": false,
               "lastModifiedInNomis": false,
-              "duplicatedReportId": null
+              "duplicatedReportId": null,
+              "latestUserAction": "REQUEST_NOT_REPORTABLE"
             }
             """,
             JsonCompareMode.STRICT,
@@ -1095,7 +1100,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "modifiedBy": "request-user",
               "createdInNomis": false,
               "lastModifiedInNomis": false,
-              "duplicatedReportId": "${duplicatedExistingReport.id}"
+              "duplicatedReportId": "${duplicatedExistingReport.id}",
+              "latestUserAction": "REQUEST_NOT_REPORTABLE"
             }
             """,
             JsonCompareMode.STRICT,
@@ -1177,7 +1183,8 @@ class ReportResourceTest : SqsIntegrationTestBase() {
               "modifiedBy": "request-user",
               "createdInNomis": false,
               "lastModifiedInNomis": false,
-              "duplicatedReportId": $expectedDuplicatedReportId
+              "duplicatedReportId": $expectedDuplicatedReportId,
+              "latestUserAction":"REQUEST_NOT_REPORTABLE"
             }
             """,
             JsonCompareMode.STRICT,


### PR DESCRIPTION
- Added `latestUserAction` field to the `Report` object and associated DTOs.
- Updated relevant mappings, tests, and builders to support the new field.