### PR TITLE
Remove max limit of 255 characters for title

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
@@ -31,7 +31,7 @@ data class CreateReportRequest(
   @param:Schema(
     description = "Brief title describing the incident",
     requiredMode = Schema.RequiredMode.REQUIRED,
-    minLength = 5
+    minLength = 5,
   )
   @field:Size(min = 5)
   val title: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/CreateReportRequest.kt
@@ -31,10 +31,9 @@ data class CreateReportRequest(
   @param:Schema(
     description = "Brief title describing the incident",
     requiredMode = Schema.RequiredMode.REQUIRED,
-    minLength = 5,
-    maxLength = 255,
+    minLength = 5
   )
-  @field:Size(min = 5, max = 255)
+  @field:Size(min = 5)
   val title: String,
   @param:Schema(
     description = "Longer summary of the incident",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateReportRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/request/UpdateReportRequest.kt
@@ -41,9 +41,8 @@ data class UpdateReportRequest(
     nullable = true,
     defaultValue = "null",
     minLength = 5,
-    maxLength = 255,
   )
-  @field:Size(min = 5, max = 255)
+  @field:Size(min = 5)
   val title: String? = null,
   @param:Schema(
     description = "Longer summary of the incident",


### PR DESCRIPTION
Found that a request was giving a 400 preventing a user from submitting a report:

[https://teams.microsoft.com/l/message/19:QL39bM156f7HJaOMCdjFuMlruPYT2fquv1TT3aU-lkc1@thread.tacv2/1776669568852?tenantId=c6874728-71e6-41fe-a9e1-2e8c36776ad8&groupId=8f25774f-8cf5-4c6a-841a-40ddc8bde57c&parentMessageId=1776669568852&teamName=Incident%20Reporting%20on%20DPS%20-%20Prisons%20Pilot&channelName=Incident%20Reporting%20on%20DPS%20-%20Prisons%20Pilot&createdTime=1776669568852](url)

Found that request was failing due to title being too long. 