### PR TITLE
IR-1582: Hyphenate Self-harm

### DIFF
--- a/docs/0003-migration.md
+++ b/docs/0003-migration.md
@@ -19,7 +19,7 @@ There will be a one-off migration of all completed incidents from NOMIS to the n
 
 The proposed approach will be :-
 * Migrate all incident reporting data from NOMIS to the new service in a one of process. These records will be role protected (mainly read-only for most users) and will be used for historical reporting and analysis. Records will be read only and can only be "edited" in NOMIS.
-* In NOMIS, switch off the ability to create new incidents of agreed types. E.g. Self harm, Assaults and Finds. No new incidents of these types will be able to be created in NOMIS. Existing records can still be edited.
+* In NOMIS, switch off the ability to create new incidents of agreed types. E.g. Self-harm, Assaults and Finds. No new incidents of these types will be able to be created in NOMIS. Existing records can still be edited.
 * Incident types can be removed on a per prison basis if needed (although not recommended), for example a set of prisons can only create new incidents (of certain types) in the new service (IRS). Other prisons can continue to use NOMIS for these types.
 * SYSCON will need to modify the incident reporting screens in NOMIS to be "edit only" for certain incident types on a per-prison basis. Config to drive this process from a screen will be required.
 * Existing reports created in NOMIS in progress it will be kept in sync to the new IRS.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/TypeFamily.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/TypeFamily.kt
@@ -50,7 +50,7 @@ enum class TypeFamily(
   MOBILE_PHONE("Mobile phone"),
   RADIO_COMPROMISE("Radio compromise"),
   RELEASE_IN_ERROR("Release in error"),
-  SELF_HARM("Self harm"),
+  SELF_HARM("Self-harm"),
   TEMPORARY_RELEASE_FAILURE("Temporary release failure"),
   TOOL_LOSS("Tool or implement loss"),
 }

--- a/src/main/resources/db/migration/V1_42__self_harm_hyphen.sql
+++ b/src/main/resources/db/migration/V1_42__self_harm_hyphen.sql
@@ -1,0 +1,9 @@
+-- Update Self-harm descriptions to have an hyphen
+
+UPDATE constant_type
+SET description='Self-harm'
+WHERE code = 'SELF_HARM_1';
+
+UPDATE constant_type_family
+SET description='Self-harm'
+WHERE code = 'SELF_HARM';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/service/NomisSyncServiceTest.kt
@@ -150,7 +150,7 @@ class NomisSyncServiceTest {
         NomisHistory(
           questionnaireId = 13212,
           type = Type.SELF_HARM_1.nomisType.toString(),
-          description = "Self harm 1",
+          description = "Self-harm 1",
           questions = listOf(),
           incidentChangeDateTime = now.minusDays(1),
           incidentChangeStaff = NomisStaff(


### PR DESCRIPTION
This requires a migration as the descriptions for
types and type families are also in the DB.

NOTE: This may have cause newly generated Self-harm reports' titles to be different than before. But there is already a precedent where a typo in a type name was changed (Food refusal) so it should be ok (See: https://github.com/ministryofjustice/hmpps-incident-reporting-api/pull/415#discussion_r2417016792)