### PR TITLE
gradle_verify workflow: Set `upload-build-artifacts`

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,6 +51,7 @@ jobs:
       postgres-username: incident_reporting
       postgres-password: incident_reporting
       localstack-tag: '4'
+      upload-build-artifacts: ${{ github.ref == 'refs/heads/main' }}
       java-version: "25"
   build:
     name: Build docker image from hmpps-github-actions


### PR DESCRIPTION
This is set like this in the Kotlin template and I think it's what's causing the docker build to fail in `main`.