### PR TITLE
IR-1664 Add FOOD_REFUSAL_2 incident type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Type.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Type.kt
@@ -56,6 +56,7 @@ enum class Type(
   FIRE_1(TypeFamily.FIRE, "FIRE"),
   FIREARM_1(TypeFamily.FIREARM, "FIREARM_ETC", active = false),
   FOOD_REFUSAL_1(TypeFamily.FOOD_REFUSAL, "FOOD_REF"),
+  FOOD_REFUSAL_2(TypeFamily.FOOD_REFUSAL, "FOOD_REF2"),
   HOSTAGE_1(TypeFamily.HOSTAGE, "HOSTAGE", active = false),
   INCIDENT_AT_HEIGHT_1(TypeFamily.INCIDENT_AT_HEIGHT, "ROOF_CLIMB", active = false),
   CONCERTED_INDISCIPLINE_1(TypeFamily.CONCERTED_INDISCIPLINE, "CON_INDISC", active = false),

--- a/src/main/resources/db/migration/V1_44__food_refusal_2_type.sql
+++ b/src/main/resources/db/migration/V1_44__food_refusal_2_type.sql
@@ -1,0 +1,13 @@
+-- add FOOD_REFUSAL_2 type (family FOOD_REFUSAL already exists)
+
+-- make room after FOOD_REFUSAL_1
+UPDATE constant_type
+  set sequence = sequence + 1
+WHERE sequence > (SELECT sequence FROM constant_type WHERE code = 'FOOD_REFUSAL_1');
+
+-- new type, immediately after FOOD_REFUSAL_1, same family
+INSERT INTO constant_type(sequence, code, description, family_code, active)
+VALUES (
+  (SELECT sequence + 1 FROM constant_type WHERE code = 'FOOD_REFUSAL_1'),
+  'FOOD_REFUSAL_2', 'Food or liquid refusal', 'FOOD_REFUSAL', true
+);


### PR DESCRIPTION
The UI service (`hmpps-incident-reporting`) is introducing a new incident type, `FOOD_REFUSAL_2`
(NOMIS code `FOOD_REF2`), as a dated successor to `FOOD_REFUSAL_1` for the **2026-07-01** Safety team
changes to the food/liquid refusal question set. A new version is used (rather than editing v1 in
place) so existing reports captured under v1 are not retro-actively altered.

The API is the source of truth for the type constants, so it must recognise the new code before the
UI can offer it or reports of this type can be created/synced. The `FOOD_REFUSAL` **family** already
exists, so only a new **type** is added.

## What changed

### Enum — `constants/Type.kt`
- Added `FOOD_REFUSAL_2(TypeFamily.FOOD_REFUSAL, "FOOD_REF2")` immediately after `FOOD_REFUSAL_1`.
- `active` defaults to `true`; the description is inherited from the existing `FOOD_REFUSAL` family
  ("Food or liquid refusal"). No change to `TypeFamily.kt`.

### Flyway migration — `db/migration/V1_44__food_refusal_2_type.sql`
- Inserts the new `constant_type` row in the same family, positioned **immediately after**
  `FOOD_REFUSAL_1` by shifting the `sequence` of all later rows up by one (same pattern as
  `V1_37__dirty_protest_types.sql`). Mid-list insertion is required because `ConstantsTableTest`
  asserts the table, ordered by `sequence`, matches the enum order exactly.
- A relative subquery is used (`sequence` of `FOOD_REFUSAL_1`) rather than a hard-coded number.
- No `constant_type_family` change (family already present). `constant_type` has no NOMIS column —
  the `FOOD_REF2` code lives only in the enum (exposed via `/constants/types`), consistent with how
  `FOOD_REF` is handled.
