### PR TITLE
IR-1779 Expose status definitions in constant_status and /constants/statuses

### DIFF
--- a/docs/0004-modeling-irs.md
+++ b/docs/0004-modeling-irs.md
@@ -162,6 +162,8 @@ classDiagram
   class constant_status {
     integer sequence
     varchar(60) description
+    varchar(255) definition
+    boolean ignore_downstream
     varchar(60) code
   }
   class constant_type {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/constants/Status.kt
@@ -6,24 +6,31 @@ package uk.gov.justice.digital.hmpps.incidentreporting.constants
  * NB:
  *   - new items should have a reasonably readable code
  *   - items cannot be removed to preserve database integrity
- *   - any additions, changes to order, codes or descriptions require a new migration of relevant constants DB table!
+ *   - any additions, changes to order, codes, descriptions or definitions require a new migration of relevant
+ *     constants DB table!
  *   - code & description are expected to be 60 chars max
+ *   - definition is expected to be 255 chars max
  */
 enum class Status(
   val description: String,
+  val definition: String,
   val nomisStatus: String?,
   val ignoreDownstream: Boolean = false,
 ) {
-  DRAFT("Draft", null),
-  AWAITING_REVIEW("Awaiting review", "AWAN"),
-  ON_HOLD("On hold", "INAN"),
-  NEEDS_UPDATING("Needs updating", "INREQ"),
-  UPDATED("Updated", "INAME"),
-  CLOSED("Closed", "CLOSE"),
+  DRAFT("Draft", "A report that has been created but not yet submitted.", null),
+  AWAITING_REVIEW(
+    "Awaiting review",
+    "A report that has been submitted for the first time and is now ready for review.",
+    "AWAN",
+  ),
+  ON_HOLD("On hold", "The report has been set aside for investigation and cannot be edited at this time.", "INAN"),
+  NEEDS_UPDATING("Needs updating", "A report that has been submitted and sent back for updates.", "INREQ"),
+  UPDATED("Updated", "A report that has been submitted more than one time and ready for review.", "INAME"),
+  CLOSED("Closed", "A report that has been submitted, reviewed and is now complete.", "CLOSE"),
 
   // the following statuses should be ignored downstream for most statistical purposes
-  DUPLICATE("Duplicate", "DUP", true),
-  NOT_REPORTABLE("Not reportable", null, true),
-  REOPENED("Reopened", null, true),
-  WAS_CLOSED("Was closed", null, true),
+  DUPLICATE("Duplicate", "A copy of a report that already exists.", "DUP", true),
+  NOT_REPORTABLE("Not reportable", "A report for an incident that did not need to be created.", null, true),
+  REOPENED("Reopened", "A report that has been reopened after it was closed/completed.", null, true),
+  WAS_CLOSED("Was closed", "A report that has been reopened from completed and then resubmitted.", null, true),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/StatusConstantDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/dto/response/StatusConstantDescription.kt
@@ -11,6 +11,11 @@ data class StatusConstantDescription(
   @param:Schema(description = "Human-readable description of this value", example = "On hold")
   val description: String,
   @param:Schema(
+    description = "Human-readable definition explaining what this value means",
+    example = "The report has been set aside for investigation and cannot be edited at this time.",
+  )
+  val definition: String,
+  @param:Schema(
     description = "Whether reports with this status should be ignored downstream for most statistical purposes",
     example = "false",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResource.kt
@@ -132,7 +132,7 @@ class ConstantsResource {
   )
   fun statuses(): List<StatusConstantDescription> {
     return Status.entries.map {
-      StatusConstantDescription(it.name, it.description, it.ignoreDownstream, it.nomisStatus)
+      StatusConstantDescription(it.name, it.description, it.definition, it.ignoreDownstream, it.nomisStatus)
     }
   }
 

--- a/src/main/resources/db/migration/V1_46__status_definitions.sql
+++ b/src/main/resources/db/migration/V1_46__status_definitions.sql
@@ -1,0 +1,19 @@
+alter table constant_status
+  add column definition varchar(255);
+
+update constant_status
+set definition = v.definition
+from (values ('DRAFT', 'A report that has been created but not yet submitted.'),
+             ('AWAITING_REVIEW', 'A report that has been submitted for the first time and is now ready for review.'),
+             ('ON_HOLD', 'The report has been set aside for investigation and cannot be edited at this time.'),
+             ('NEEDS_UPDATING', 'A report that has been submitted and sent back for updates.'),
+             ('UPDATED', 'A report that has been submitted more than one time and ready for review.'),
+             ('CLOSED', 'A report that has been submitted, reviewed and is now complete.'),
+             ('DUPLICATE', 'A copy of a report that already exists.'),
+             ('NOT_REPORTABLE', 'A report for an incident that did not need to be created.'),
+             ('REOPENED', 'A report that has been reopened after it was closed/completed.'),
+             ('WAS_CLOSED', 'A report that has been reopened from completed and then resubmitted.')) as v(code, definition)
+where constant_status.code = v.code;
+
+alter table constant_status
+  alter column definition set not null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ConstantsTableTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/jpa/ConstantsTableTest.kt
@@ -87,12 +87,14 @@ class ConstantsTableTest : IntegrationTestBase() {
       mapOf(
         "code" to it.name,
         "description" to it.description,
+        "definition" to it.definition,
+        "ignore_downstream" to it.ignoreDownstream,
       )
     }
     val actual = listAllConstants(
       // language=postgresql
       """
-      SELECT code, description FROM constant_status
+      SELECT code, description, definition, ignore_downstream FROM constant_status
       """,
     )
     assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incidentreporting/resource/ConstantsResourceTest.kt
@@ -121,12 +121,14 @@ class ConstantsResourceTest : SqsIntegrationTestBase() {
         mapOf(
           "code" to "DRAFT",
           "description" to "Draft",
+          "definition" to "A report that has been created but not yet submitted.",
           "nomisCode" to null,
           "ignoreDownstream" to false,
         ),
         mapOf(
           "code" to "ON_HOLD",
           "description" to "On hold",
+          "definition" to "The report has been set aside for investigation and cannot be edited at this time.",
           "nomisCode" to "INAN",
           "ignoreDownstream" to false,
         ),


### PR DESCRIPTION
## What

The analytical platform team asked whether the longer status *definitions* the UI shows under "Help with statuses" could be exposed in the `constant_status` table, so they can display the same wording in their own systems.

That text previously lived only in the UI, hard-coded in `hmpps-incident-reporting/server/reportConfiguration/constants/statusHints.ts`. This PR makes the API's `Status` enum the source of truth for it.

- `Status` enum gains a `definition` property, populated verbatim from `statusHints.ts` (all 10 statuses).
- `V1_46__status_definitions.sql` adds `constant_status.definition varchar(255)`, backfills every row, then sets `not null`.
- `definition` is exposed on `GET /constants/statuses`. This is additive — existing consumers are unaffected.

## Tests

`ConstantsTableTest.status table` now compares `code`, `description`, `definition` **and** `ignore_downstream` from the migrated database against `Status.entries`, so the migration and the enum can no longer drift apart. `ignore_downstream` was an existing gap in that assertion and is closed here at no extra cost.

`ConstantsResourceTest` sample maps updated for the new field.

## Note on the UI

Keeping the API and UI copies of this text in sync was **out of scope**. The UI still renders from its own `statusHints.ts`, so the two can drift — nothing currently fails if one is edited and not the other. Worth a follow-up if we want that guaranteed: either the UI reads `definition` from the API, or a test compares the two.

Incident *type* hints (`typeHints.ts`) are also out of scope.

## Docs

`docs/0004-modeling-irs.md` schema diagram updated for `constant_status` — it was also missing `ignore_downstream`, so that is included.