### PR TITLE
IR-1869 Point CODEOWNERS at manage-safety-devs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/hmpps-incident-reporting
+* @ministryofjustice/manage-safety-devs


### PR DESCRIPTION
Repoints `CODEOWNERS` from the per-service team to `@ministryofjustice/manage-safety-devs`.

Manage Safety is consolidating its seven per-service GitHub teams into two — `manage-safety-devs` for non-production and `manage-safety-live` for preprod and production. This gives the service area an SC-clearance boundary it currently lacks, cuts onboarding from up to seven team additions to two, and shortens the AWS SSO SAML assertion.

`manage-safety-devs` already exists, has all 13 Manage Safety members, and holds admin on this repository, so review routing keeps working from the moment this merges.

Part of https://dsdmoj.atlassian.net/browse/IR-1863 (IR-1869).